### PR TITLE
feat: use libpq compatible env vars for db connection

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -30,7 +30,7 @@ RUN \
 		dirmngr \
 		gnupg2 && \
 	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
-	until apt-key adv --keyserver pgp.mit.edu --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'; do sleep 10; done && \
+	until apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'; do sleep 10; done && \
 	apt-get clean -y && \
 	apt-get autoremove -y && \
 	apt-get autoclean -y && \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -7,7 +7,7 @@ RUN \
 	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		locales=2.28-10 && \
+		locales && \
 	echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
 	locale-gen en_US.utf8 && \
 	apt-get clean -y && \

--- a/rstudio/rstudio-start.sh
+++ b/rstudio/rstudio-start.sh
@@ -35,5 +35,11 @@ echo "S3_PREFIX='${S3_PREFIX}'" >> /etc/R/Renviron.site
 echo "AWS_DEFAULT_REGION='${AWS_DEFAULT_REGION}'" >> /etc/R/Renviron.site
 echo "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI='${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}'" >> /etc/R/Renviron.site
 echo "TZ='Europe/London'" >> /etc/R/Renviron.site
+echo "PGHOST='${PGHOST}'" >> /etc/R/Renviron.site
+echo "PGPORT='${PGPORT}'" >> /etc/R/Renviron.site
+echo "PGSSLMODE='${PGSSLMODE}'" >> /etc/R/Renviron.site
+echo "PGDATABASE='${PGDATABASE}'" >> /etc/R/Renviron.site
+echo "PGUSER='${PGUSER}'" >> /etc/R/Renviron.site
+echo "PGPASSWORD='${PGPASSWORD}'" >> /etc/R/Renviron.site
 
 sudo -E -H -u rstudio /usr/lib/rstudio-server/bin/rserver


### PR DESCRIPTION
This is so we can have simpler code to connect to the datasets db from R. This is required since R does not seem to automatically inherit all parent environment variables.