### PR TITLE
build(deps): include procps in Theia

### DIFF
--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -38,6 +38,7 @@ RUN \
 		man-db \
 		vim \
 		emacs \
+		procps \
 		sudo \
         libsecret-1.0 && \
 	curl -sL https://deb.nodesource.com/setup_12.x | bash - && \


### PR DESCRIPTION
When trying to bump Theia version, there are errors since it can't find ps. So installing now and seeing if it all works fine in the existing version to make the changes when later bumping Theia version smaller.