### PR TITLE
build(deps): upgrade-got-to-11.8.5

### DIFF
--- a/theia/yarn.lock
+++ b/theia/yarn.lock
@@ -901,7 +901,7 @@
     debug "^4.1.1"
     env-paths "^2.2.0"
     fs-extra "^8.1.0"
-    got "^9.6.0"
+    got "^11.8.5"
     progress "^2.0.3"
     semver "^6.2.0"
     sumchecker "^3.0.1"
@@ -3711,7 +3711,7 @@ electron-rebuild@^3.2.7:
     debug "^4.1.1"
     detect-libc "^1.0.3"
     fs-extra "^10.0.0"
-    got "^11.7.0"
+    got "^11.8.5"
     lzma-native "^8.0.5"
     node-abi "^3.0.0"
     node-api-version "^0.1.4"
@@ -4558,7 +4558,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-got@^11.7.0:
+got@^11.8.5:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -4575,9 +4575,9 @@ got@^11.7.0:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-got@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+got@^11.8.5:
+  version "11.8.5"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
   integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
   dependencies:
     "@sindresorhus/is" "^0.14.0"


### PR DESCRIPTION
- upgrade GOT to version 11.8.5

The GOT package before 11.8.5 and 12.1.0 for Node.js allows a redirect to a UNIX socket.