### PR TITLE
build(deps): upgrade socket.io-parser

### DIFF
--- a/theia/package.json
+++ b/theia/package.json
@@ -17,22 +17,25 @@
     }
   },
   "dependencies": {
-    "@theia/callhierarchy": "^1.27.0",
-    "@theia/file-search": "^1.27.0",
-    "@theia/git": "^1.27.0",
-    "@theia/markers": "^1.27.0",
-    "@theia/messages": "^1.27.0",
-    "@theia/navigator": "^1.27.0",
-    "@theia/outline-view": "^1.27.0",
-    "@theia/plugin-ext-vscode": "^1.27.0",
-    "@theia/preferences": "^1.27.0",
-    "@theia/preview": "^1.27.0",
-    "@theia/search-in-workspace": "^1.27.0",
-    "@theia/terminal": "^1.27.0",
-    "@theia/vsx-registry": "^1.27.0"
+    "@theia/callhierarchy": "^1.31.0",
+    "@theia/file-search": "^1.31.0",
+    "@theia/git": "^1.31.0",
+    "@theia/markers": "^1.31.0",
+    "@theia/messages": "^1.31.0",
+    "@theia/navigator": "^1.31.0",
+    "@theia/outline-view": "^1.31.0",
+    "@theia/plugin-ext-vscode": "^1.31.0",
+    "@theia/preferences": "^1.31.0",
+    "@theia/preview": "^1.31.0",
+    "@theia/search-in-workspace": "^1.31.0",
+    "@theia/terminal": "^1.31.0",
+    "@theia/vsx-registry": "^1.31.0"
   },
   "devDependencies": {
-    "@theia/cli": "^1.28.0"
+    "@theia/cli": "^1.31.0"
+  },
+  "resolutions": {
+    "socket.io-parser": "~4.2.1"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build && yarn run download:plugins",

--- a/theia/yarn.lock
+++ b/theia/yarn.lock
@@ -849,7 +849,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.10.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.10.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
   integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
@@ -900,21 +900,20 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@electron/get@^1.12.4":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
-  integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
+"@electron/get@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.2.tgz#ae2a967b22075e9c25aaf00d5941cd79c21efd7e"
+  integrity sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==
   dependencies:
     debug "^4.1.1"
     env-paths "^2.2.0"
     fs-extra "^8.1.0"
-    got "^9.6.0"
+    got "^11.8.5"
     progress "^2.0.3"
     semver "^6.2.0"
     sumchecker "^3.0.1"
   optionalDependencies:
     global-agent "^3.0.0"
-    global-tunnel-ng "^2.7.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -967,6 +966,36 @@
   integrity sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==
   dependencies:
     cross-spawn "^7.0.1"
+
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz#9571b87be3a3f2c46de05585470bc4f3af2f6f00"
+  integrity sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz#bfbc6936ede2955218f5621a675679a5fe8e6f4c"
+  integrity sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz#22555e28382af2922e7450634c8a2f240bb9eb82"
+  integrity sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz#ffb6ae1beea7ac572b6be6bf2a8e8162ebdd8be7"
+  integrity sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==
+
+"@msgpackr-extract/msgpackr-extract-linux-x64@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz#7caf62eebbfb1345de40f75e89666b3d4194755f"
+  integrity sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz#f2d8b9ddd8d191205ed26ce54aba3dfc5ae3e7c9"
+  integrity sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1116,11 +1145,6 @@
   dependencies:
     execa "^0.2.2"
 
-"@sindresorhus/is@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
-  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
-
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
@@ -1131,17 +1155,15 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz#8863915676f837d9dad7b76f50cb500c1e9422e9"
   integrity sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
+  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
 "@stroncium/procfs@^1.0.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@stroncium/procfs/-/procfs-1.2.1.tgz#6b9be6fd20fb0a4c20e99a8695e083c699bb2b45"
   integrity sha512-X1Iui3FUNZP18EUvysTHxt+Avu2nlVzyf90YM8OYgP6SGzTzzX/0JgObfO1AQQDzuZtNNz29bVh8h5R97JrjxA==
-
-"@szmarczak/http-timer@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
-  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  dependencies:
-    defer-to-connect "^1.0.1"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -1150,17 +1172,17 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@theia/application-manager@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.28.0.tgz#e8b42b14a8d450f6791865e520209b5555f4f1ff"
-  integrity sha512-5OycfBdJZEDQ52wKsyCau6h9fJKURv1aYkBFFxwNvAXVt+0peCRqzeCFYNBY7S4JyyvkexQwXrl42NBn6nVhvg==
+"@theia/application-manager@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.31.0.tgz#df6bf4eec433ec08da97fbe3f4fa1c7f1bd2b20f"
+  integrity sha512-8StzsnL939J3erjE8RgNpTvAsAHPX1IhR+VKvcY1VhVWZAx4OHSn5BwOo+aZ6JkLL1/KSFJQcxowS0GXj87Ibw==
   dependencies:
     "@babel/core" "^7.10.0"
     "@babel/plugin-transform-classes" "^7.10.0"
     "@babel/plugin-transform-runtime" "^7.10.0"
     "@babel/preset-env" "^7.10.0"
-    "@theia/application-package" "1.28.0"
-    "@theia/ffmpeg" "1.28.0"
+    "@theia/application-package" "1.31.0"
+    "@theia/ffmpeg" "1.31.0"
     "@types/fs-extra" "^4.0.2"
     "@types/semver" "^7.3.8"
     babel-loader "^8.2.2"
@@ -1173,6 +1195,7 @@
     fs-extra "^4.0.2"
     ignore-loader "^0.1.2"
     less "^3.0.3"
+    mini-css-extract-plugin "^2.6.1"
     node-abi "*"
     path-browserify "^1.0.1"
     semver "^7.3.5"
@@ -1180,6 +1203,7 @@
     source-map "^0.6.1"
     source-map-loader "^2.0.1"
     source-map-support "^0.5.19"
+    string-replace-loader "^3.1.0"
     style-loader "^2.0.0"
     umd-compat-loader "^2.1.2"
     webpack "^5.48.0"
@@ -1187,10 +1211,10 @@
     worker-loader "^3.0.8"
     yargs "^15.3.1"
 
-"@theia/application-package@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.27.0.tgz#e51b240294e10bce169024a99fba2fa10cbc6d53"
-  integrity sha512-yn/zRV3OVrxQOgFfJU3Pbv6rk4+VkhFS9y1mrr4w0ZyemLJ8qSuBU6CEHgQ04GFCq7hJHiZ/hyoCldVxGKaY+A==
+"@theia/application-package@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.31.0.tgz#271340e51ba400b84dbd912c6a8a7b2dd2c332d7"
+  integrity sha512-czvM6nNIqCUHge0JECW2HMN42rafJNHWaK1w7+yfDPYfStbnMNUbsi0shQm21Kvs1zyEI6ZG7HcAAxmj4kmJNw==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -1204,55 +1228,38 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/application-package@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.28.0.tgz#b07a6e35439260a5fb6e7a65d65b209e5e46dd55"
-  integrity sha512-eiJL2lV4hVXlG1DACeimQj8VfnpOxPiEU4tX0ozgEAViqPDQs2tYyiO9ihj6Gp/T8vqFXO4LG+jgKGMmRNNsMA==
+"@theia/bulk-edit@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/bulk-edit/-/bulk-edit-1.31.0.tgz#1024e88ee3f918c88d132d52c2fb51d2fce3ceea"
+  integrity sha512-RMWN78Cb3Q5/3Sp48xIOxO3HvJTnCZMbPws21CkLWglb+z8ubyfDzxjbOskGoGshN819btwkOb5DEG4tnCkL7w==
   dependencies:
-    "@types/fs-extra" "^4.0.2"
-    "@types/request" "^2.0.3"
-    "@types/semver" "^5.4.0"
-    "@types/write-json-file" "^2.2.1"
-    deepmerge "^4.2.2"
-    fs-extra "^4.0.2"
-    is-electron "^2.1.0"
-    nano "^9.0.5"
-    request "^2.82.0"
-    semver "^5.4.1"
-    write-json-file "^2.2.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/workspace" "1.31.0"
 
-"@theia/bulk-edit@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/bulk-edit/-/bulk-edit-1.27.0.tgz#57f10dbd8e30878e4cea18f143423bc481319b40"
-  integrity sha512-DjG9awhCrtiOKSGEZqpm8OmAtHRVvVpBFdU5holCM99HvBg4Y8BfKn252Iev41Clba5JEVFecOfhOe9HnYa1mQ==
+"@theia/callhierarchy@1.31.0", "@theia/callhierarchy@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-1.31.0.tgz#242dcf9afab39002e531df790eef6f01520002ed"
+  integrity sha512-00F3b9T7oB6MWk0GfoDYJ3B+VN1u8P3ejp7T0mPxSFcZJB35M2GobuN3P0YQ8v4bK0N1Gea9xhjDOooe8Guj1g==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/workspace" "1.27.0"
-
-"@theia/callhierarchy@1.27.0", "@theia/callhierarchy@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-1.27.0.tgz#3f2ff2a6abbc9d6de4f800ea52c3d207c785d68c"
-  integrity sha512-ORCit2eSUvxQfBky8vBFLby8yJHhGOxuLjNtK6DCSen+btg/f3lQCzd4uFf+UhY8yYQi2g27JoM7kSLFtv+o8g==
-  dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
     ts-md5 "^1.2.2"
 
-"@theia/cli@^1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.28.0.tgz#784ecbaa7e4d0bd19a6d467ea2befb9377dff77f"
-  integrity sha512-2VG8ZWNOB8XcsYc0GII6ArFwWqHf1Nuse6fUtfBIUNrnXQ6OuJHsIN23CTzoYw6zLdtyP9bQunG8OyPArX6Srg==
+"@theia/cli@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.31.0.tgz#30fffc106eb87c5508aa840846a8c00550b18e13"
+  integrity sha512-ZwcQbjEkw92iYO+/tTLtz1qkcj3VDSuMACr8jk5AcW9g6I85wZsqcRZAIWKfozmqPX71OVO7FGa5H5q49/HD3g==
   dependencies:
-    "@theia/application-manager" "1.28.0"
-    "@theia/application-package" "1.28.0"
-    "@theia/ffmpeg" "1.28.0"
-    "@theia/localization-manager" "1.28.0"
-    "@theia/ovsx-client" "1.28.0"
-    "@theia/request" "1.28.0"
+    "@theia/application-manager" "1.31.0"
+    "@theia/application-package" "1.31.0"
+    "@theia/ffmpeg" "1.31.0"
+    "@theia/localization-manager" "1.31.0"
+    "@theia/ovsx-client" "1.31.0"
+    "@theia/request" "1.31.0"
     "@types/chai" "^4.2.7"
     "@types/mocha" "^5.2.7"
     "@types/node-fetch" "^2.5.7"
@@ -1260,26 +1267,28 @@
     chai "^4.2.0"
     chalk "4.0.0"
     decompress "^4.2.1"
+    glob "^8.0.3"
+    log-update "^4.0.0"
     mocha "^7.0.0"
     puppeteer "^2.0.0"
     puppeteer-to-istanbul "^1.2.2"
     temp "^0.9.1"
     yargs "^15.3.1"
 
-"@theia/console@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/console/-/console-1.27.0.tgz#1ae6eb5c5f534cc149f692801b543ae00e260330"
-  integrity sha512-ps0GCYouBLDu2yr57vB9ncb79R2oubvz/CJTEnl6DMrjkpZ9iw/+LMMDPieHxGE/wrYwsrrou0y9Voa3rvSWVA==
+"@theia/console@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/console/-/console-1.31.0.tgz#cb227813bd91ed55b4d40dd712b8ae21ab1d1a2b"
+  integrity sha512-deNmZMWj4tBofzPmMxrrT+2RIMJFHZw2URMtNCuo0YZ6Xjm+X0NE3/DAwAAnKMX7A09nc1kuKhDs8z9piWSteg==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
+    "@theia/core" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
     anser "^2.0.1"
 
-"@theia/core@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.27.0.tgz#509db566ee3b061948c92abe0f4fb41f4b907423"
-  integrity sha512-Z52q3zqxqbzBOG3DZ7AKYd8hdiu0cHV70fHc3IyAZ4Anieur5fFOdr8TUlrr4PO3ZCzWNu2MHkv+hvSDdanPnQ==
+"@theia/core@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.31.0.tgz#30f779b7f340c000d0233ec13924e009ac7a8e33"
+  integrity sha512-EU7GUsWNjgu5g8JaVCb6IZUsNDk+KQJB/TMXkdy5I2M+FnOSfqOi3wlbWIB2i/MuKY+QszGyXrN4TbZDJeczsg==
   dependencies:
     "@babel/runtime" "^7.10.0"
     "@phosphor/algorithm" "1"
@@ -1292,8 +1301,8 @@
     "@phosphor/signaling" "1"
     "@phosphor/virtualdom" "1"
     "@phosphor/widgets" "1"
-    "@theia/application-package" "1.27.0"
-    "@theia/request" "1.27.0"
+    "@theia/application-package" "1.31.0"
+    "@theia/request" "1.31.0"
     "@types/body-parser" "^1.16.4"
     "@types/cookie" "^0.3.3"
     "@types/dompurify" "^2.2.2"
@@ -1302,9 +1311,8 @@
     "@types/lodash.debounce" "4.0.3"
     "@types/lodash.throttle" "^4.1.3"
     "@types/markdown-it" "^12.2.3"
-    "@types/react" "^16.8.0"
-    "@types/react-dom" "^16.8.0"
-    "@types/react-virtualized" "^9.18.3"
+    "@types/react" "^18.0.15"
+    "@types/react-dom" "^18.0.6"
     "@types/route-parser" "^0.1.1"
     "@types/safer-buffer" "^2.1.0"
     "@types/ws" "^5.1.2"
@@ -1317,6 +1325,7 @@
     drivelist "^9.0.2"
     es6-promise "^4.2.4"
     express "^4.16.3"
+    fast-json-stable-stringify "^2.1.0"
     file-icons-js "~1.0.3"
     font-awesome "^4.7.0"
     fs-extra "^4.0.2"
@@ -1330,13 +1339,14 @@
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
     markdown-it "^12.3.2"
+    msgpackr "^1.6.1"
     nsfw "^2.1.2"
     p-debounce "^2.1.0"
     perfect-scrollbar "^1.3.0"
-    react "^16.8.0"
-    react-dom "^16.8.0"
+    react "^18.2.0"
+    react-dom "^18.2.0"
     react-tooltip "^4.2.21"
-    react-virtualized "^9.20.0"
+    react-virtuoso "^2.17.0"
     reflect-metadata "^0.1.10"
     route-parser "^0.0.5"
     safer-buffer "^2.1.2"
@@ -1348,66 +1358,66 @@
     ws "^7.1.2"
     yargs "^15.3.1"
 
-"@theia/debug@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-1.27.0.tgz#4031335027540d51815467ac21eee4d7535a5448"
-  integrity sha512-0ImDGg0iAcI5DVBOeF1HgL5IVDssv7E1fmvsOk8dNS251qm+eeC/GnKgOj3RFNV2zfu37cjjQXNn1SHdO0cn+g==
+"@theia/debug@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-1.31.0.tgz#8d7eece0767285cdec71ebbd649f92b9f3541411"
+  integrity sha512-chOjzQZ3DUiR5XcGvx2Ral+hNezxls7ydu7U4/UMSYGgMzpGPgsljRiDqwl+MOiSbsy4q/xjgJgqA9rnurwFfw==
   dependencies:
-    "@theia/console" "1.27.0"
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/markers" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/output" "1.27.0"
-    "@theia/process" "1.27.0"
-    "@theia/task" "1.27.0"
-    "@theia/terminal" "1.27.0"
-    "@theia/variable-resolver" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/console" "1.31.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/markers" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/output" "1.31.0"
+    "@theia/process" "1.31.0"
+    "@theia/task" "1.31.0"
+    "@theia/terminal" "1.31.0"
+    "@theia/variable-resolver" "1.31.0"
+    "@theia/workspace" "1.31.0"
+    "@vscode/debugprotocol" "^1.51.0"
     jsonc-parser "^2.2.0"
     mkdirp "^0.5.0"
     p-debounce "^2.1.0"
     requestretry "^7.0.0"
     tar "^4.0.0"
     unzip-stream "^0.3.0"
-    vscode-debugprotocol "^1.32.0"
 
-"@theia/editor@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.27.0.tgz#c79164c06bc0bfcd3e0e74c206283e3c9d0fec5d"
-  integrity sha512-C6DPi7hP0gyLG0aqCJLB+WHiyOVwnFjY+U0YiC205tXncOTGhWcV4VO+V+0xwnTJsjGG5/ChAr57KQLA5MfyRQ==
+"@theia/editor@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.31.0.tgz#5ee1918c77f22e6d0e682b199f48ad4b4a57402b"
+  integrity sha512-xno+LD3axMD+XNUi851sJFBlEP/kdFXm0VeUoh5yIovP8LPxmaYt3cjNE1A0HlXqv1ylhkRbpgiq2vdSo/4lZQ==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/variable-resolver" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/variable-resolver" "1.31.0"
 
-"@theia/ffmpeg@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.28.0.tgz#3d150b7d85fbdf47b7fd2f90a993da9dc745ddab"
-  integrity sha512-chMeIm0KZljo/Mp91+S2h/Z/M3vj9lex6E96x/jGNc8oxxE4Pnn4VEi4IPBZ7a4W55dd0w+PmOBFhiGDYJjaPA==
+"@theia/ffmpeg@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.31.0.tgz#3447f008247cf283d5055dd7fea158836aaba365"
+  integrity sha512-Kg2wkiyKS77vBOQMlIwOmX9caI1il9qLiFiT/dBrX7AUQLP4xrOLz6WT5lhZhVYj6rAm+Wn/S3eav6BuXISP6w==
   dependencies:
-    "@electron/get" "^1.12.4"
+    "@electron/get" "^2.0.0"
     unzipper "^0.9.11"
 
-"@theia/file-search@1.27.0", "@theia/file-search@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/file-search/-/file-search-1.27.0.tgz#d1c0f484146c4ead2180761d8ab44174572c7bde"
-  integrity sha512-GJra+1/URHa9kg0Zc8ev1no0KRGUQ+dmpT0ynVfvZZUpz5u1U13wKbaB2tVOmlQ/bmetpB1JALB/IIAGqVKf6A==
+"@theia/file-search@1.31.0", "@theia/file-search@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/file-search/-/file-search-1.31.0.tgz#2d241b04435b84cb5dcffbfdc38f733b366f7908"
+  integrity sha512-u8H64qDb3kBcTnjgRvOZ9X9mBHOr6ZXfTBQD5HRbwIYRO+mt185BuPMyVVQfYz+g9PG7v0Bz5qGD1MbE1c6+1g==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/process" "1.27.0"
-    "@theia/workspace" "1.27.0"
-    vscode-ripgrep "^1.2.4"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/process" "1.31.0"
+    "@theia/workspace" "1.31.0"
+    "@vscode/ripgrep" "^1.14.2"
 
-"@theia/filesystem@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.27.0.tgz#126a77c749097a5c81d31880e8466d096e51e041"
-  integrity sha512-UF+LgUFITruRP8K+exLm1NU3X52rnWo3loMDRtDQZxIKidMlxbWsIyvqD3UfEjd+QL8tvAX78n7Kol9awVjkfQ==
+"@theia/filesystem@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.31.0.tgz#16db0b9320f2d5a78805e4c667a310fce9774154"
+  integrity sha512-hrcmHKUJ2IoOIv3scayxxI6RCio/AKDVsrRJp1CMZx3X2WC2Tj65baGEbtkBFRVwJ0iZkfjoZxD0m18ApGwVSA==
   dependencies:
-    "@theia/core" "1.27.0"
+    "@theia/core" "1.31.0"
     "@types/body-parser" "^1.17.0"
     "@types/multer" "^1.4.7"
     "@types/rimraf" "^2.0.2"
@@ -1424,23 +1434,23 @@
     uuid "^8.0.0"
     vscode-languageserver-textdocument "^1.0.1"
 
-"@theia/git@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/git/-/git-1.27.0.tgz#5362d31ba5f41a27f78b930292489d07bfb8a865"
-  integrity sha512-12yKhFdNtoHsephHghD1m6K1leohCR/EhXG1jlZofOnc8C5Js/QWTD5ci/LXvVelmXT8MgZKNRwATUmkwn2q5Q==
+"@theia/git@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/git/-/git-1.31.0.tgz#beeeb86733430cb08a1b5d2cf91c0d9bd2cf7ac0"
+  integrity sha512-ohwGtbU16CkgfZ2BV6hJTPVZcgyLFl5dqDRQ8inXXvN6YIT4Gn6Q96/TY5JQcx5oNCbY2W0NeuwxovNY0UaB/g==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/navigator" "1.27.0"
-    "@theia/scm" "1.27.0"
-    "@theia/scm-extra" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/navigator" "1.31.0"
+    "@theia/scm" "1.31.0"
+    "@theia/scm-extra" "1.31.0"
+    "@theia/workspace" "1.31.0"
     "@types/diff" "^3.2.2"
     "@types/p-queue" "^2.3.1"
     diff "^3.4.0"
-    dugite-extra "0.1.15"
+    dugite-extra "0.1.16"
     find-git-exec "^0.0.4"
     find-git-repositories "^0.1.1"
     luxon "^2.4.0"
@@ -1448,10 +1458,10 @@
     p-queue "^2.4.2"
     ts-md5 "^1.2.2"
 
-"@theia/localization-manager@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.28.0.tgz#740b84c3e90280e4fe543ad2f686ae8e966b164d"
-  integrity sha512-OBdN8nXnV2hkzuFdOK3MgS7FcQdgKQV9PL0JRGKc//G3hRV2sIinq3WeU9Hczqvdyx3FKycI2OagSgLRyGNixw==
+"@theia/localization-manager@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.31.0.tgz#2ce10f414cb9326f356dd0f2cd07da005428453a"
+  integrity sha512-wdLn3Ke/w5iSFTnXSSz4UvnBLYkNNn0CCL7BTrhZaxmkqWwtP87u8Ux2AKI3BLRoR2Sb0NBYEzgALoRph/Nh3g==
   dependencies:
     "@types/bent" "^7.0.1"
     "@types/fs-extra" "^4.0.2"
@@ -1462,154 +1472,149 @@
     glob "^7.2.0"
     typescript "~4.5.5"
 
-"@theia/markers@1.27.0", "@theia/markers@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.27.0.tgz#1b36da2829def83e9c490ca4e870d0c43e5380a2"
-  integrity sha512-vkFkiWsRUReEsyyUURx/hcrqN9qSmwW4CA11ukCcqinWzRKPgO0YBdx/FKGA8uapnmNwRURtVWY1sOP3bhzoUQ==
+"@theia/markers@1.31.0", "@theia/markers@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.31.0.tgz#d8bc53f7f10a208395594683fd6ec19935a4dc03"
+  integrity sha512-SWdTGd2zSFUGJd+Kyd/uoTLj+e1wbeFBiSqDQ0uyyajuuvCGrv/mZ2wbw7C66iqKM7qf3UQ4n3Grm3ORWY8XPQ==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/workspace" "1.31.0"
 
-"@theia/messages@1.27.0", "@theia/messages@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.27.0.tgz#1d876127bbe3cd7ccc95744d081b8a49300cf3de"
-  integrity sha512-g1MaKAVEAqKJu7Px2cdrbrt/AKk90wSaEXw1MK2GHp3RM6Jbr5oQ6YPRuzpUp9jGfz9k07ypdRgu7arRJ58LPg==
+"@theia/messages@1.31.0", "@theia/messages@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.31.0.tgz#c315cac83b4e8b6c5ad8ce0f343b691c51c89ffd"
+  integrity sha512-qbb8IyWsCMtVKtyOBjxmyBPH2BOKqs712qMznmiujf6TEMaabBmkPAgXxfj/dF/Lh4U/fGtIcfSjdWAUNuF4WQ==
   dependencies:
-    "@theia/core" "1.27.0"
+    "@theia/core" "1.31.0"
     react-perfect-scrollbar "^1.5.3"
     ts-md5 "^1.2.2"
 
-"@theia/mini-browser@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/mini-browser/-/mini-browser-1.27.0.tgz#da6813455154b31cf0640e8d81f66ec79294549e"
-  integrity sha512-6lAFix3aEyjDcWxyNXYzZn02vL5BipYH2D1YELb8sqbXOByV+krX9d1LyjjSAHzRtHcsGbw+lUdpPBUgTs8xoA==
+"@theia/mini-browser@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/mini-browser/-/mini-browser-1.31.0.tgz#e67be6c1626f4ce3d2db872404a9f5dfb0418a53"
+  integrity sha512-ov5G7flm0UevvJnQbv+QeHjCMq8ibuY3fx1h4vgR+gD7TAOjk5592ZQUevKDthvKgSpEXO8qpvRmbOc+50cXAw==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/filesystem" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/filesystem" "1.31.0"
     "@types/mime-types" "^2.1.0"
     mime-types "^2.1.18"
     pdfobject "^2.0.201604172"
     uuid "^8.0.0"
     vhost "^3.0.2"
 
-"@theia/monaco-editor-core@1.65.2":
-  version "1.65.2"
-  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.65.2.tgz#91bc9ce2afe1b6011789ce83a5bee898f0153430"
-  integrity sha512-2UmGjcEW/YpZ2DsFuVevKR3CBMe44Rd6DgwP/5s4pyOe6K/s6TKY7Sh24lO0BXetQKofAEx3zh+ldEvjwhNwDw==
+"@theia/monaco-editor-core@1.67.2":
+  version "1.67.2"
+  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.67.2.tgz#d89163fa4f15560e72413791dc6a406a7c732807"
+  integrity sha512-KjDqHiTSOvnQOkV5qOJaUYwOaMjzpbqJZNRi0RKlBkCjcd/wjGlu5kjsgSDu6BbMnk51oQ9GgoDq/ppjJVaa7A==
 
-"@theia/monaco@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.27.0.tgz#0fc29730f1d01ec996355eb50be32cadb053721b"
-  integrity sha512-fRJO2/7aW5/vzCJjALqtoLAhKUi7C5wJrEQ82ZFpV/9E09O++Op0+Ovyyn7SlgRzjD4FlVTcj8YRifX+5vBsYA==
+"@theia/monaco@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.31.0.tgz#97d3cfd60da1fc39e46324b3ec78e62330527890"
+  integrity sha512-QNMZhGPoiu56Hfqc3wKLHIRhxi5BKiCFETpmbdtYRNbQxBYzYo5mh6efRlaGtBuRsnaSIemlkBYpGg0mq4J/2Q==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/markers" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/outline-view" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/markers" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/outline-view" "1.31.0"
     fast-plist "^0.1.2"
     idb "^4.0.5"
     jsonc-parser "^2.2.0"
-    onigasm "^2.2.0"
-    vscode-textmate "^4.4.0"
+    vscode-oniguruma "1.6.1"
+    vscode-textmate "7.0.1"
 
-"@theia/navigator@1.27.0", "@theia/navigator@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.27.0.tgz#01039c52a05fe5a97715dde8b3c07e7e1b169a84"
-  integrity sha512-9NJvOLFAerF3P6RBsgLd693OOATCqTiSm8FEZ1PL0u0IWY6gHNxNXj+YnFUst4I69tdIhRqV04NAw8n1/NxB1A==
+"@theia/navigator@1.31.0", "@theia/navigator@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.31.0.tgz#1cbb28ce2afa85106ef27bd90460367fa64ebf0e"
+  integrity sha512-e2NrPLCoqUl+h+UGSSAtMrjbt6ccvc9a82JE8S3DvLeDbDSOJxzzaw1GPoSE6o1NFpxHcKGJ1wQjFyQx96vS0Q==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/workspace" "1.31.0"
     minimatch "^3.0.4"
 
-"@theia/outline-view@1.27.0", "@theia/outline-view@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.27.0.tgz#cb9f11607e9c2fe77b2f00f3b2bb28634e1569e0"
-  integrity sha512-aBdMFrhK7VISgx9TwjHXJ6vv1tPeI8gEUUWX89pE7NhBwcbJeTCOHk8ZNj2dGx/VOfu8kuJxSTPhM02hNN7ceg==
+"@theia/outline-view@1.31.0", "@theia/outline-view@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.31.0.tgz#73edaddf4e90dfd0fb6e09619459cebcf3b92f1c"
+  integrity sha512-4O0ity1eKgsikioSyLtZMZuAs98HMzGZ3d+w9n51U01wGCVkKv2M5wJgc00RtZVG8rMgLsGi0Ma2s9+fz9maGw==
   dependencies:
-    "@theia/core" "1.27.0"
+    "@theia/core" "1.31.0"
 
-"@theia/output@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-1.27.0.tgz#462ddbaa0dce285eba3dbda920dc2e7b14e20768"
-  integrity sha512-1GzcRD8Rip4ijea1YduPFXsGrMCICNM/1ST4YJcNQZLVveSIOeaHPtpQeesIHbL7hvsmwUENVH67tCmbaCLS1w==
+"@theia/output@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-1.31.0.tgz#7ed81e6e8a5d516056ed287b5d861b4704d84202"
+  integrity sha512-3XNzD2p+G21knxTtdCzf92PpqNKzI5dqTnh+Y9rs/Rq+1zwbQZh+YVgFi5sC1V+xMnp9Bml8i2CLbbEB4SceQg==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
     "@types/p-queue" "^2.3.1"
     p-queue "^2.4.2"
 
-"@theia/ovsx-client@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.27.0.tgz#584b7126f5f1d51c5b83a3bcf480c2e3a060039e"
-  integrity sha512-jxPhr2sLwzFQdUVJY9L8aJKHxodbDidWtoH8xW8dPvIdBtd0m6a01mEj1ScEUs3Isto3dT96sMJdBZxRzEnanQ==
+"@theia/ovsx-client@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.31.0.tgz#d194d078d5e958fbc74938f59c6ce3c26be8f655"
+  integrity sha512-tgAlQCbYCaxaRUyFAXygCkWuHgL7+IbiOLmEogTwxoUEDx0NO37lmiIv9XkAoCdHtR553rnjYCple+edfmPTWg==
   dependencies:
-    "@theia/request" "1.27.0"
+    "@theia/request" "1.31.0"
     semver "^5.4.1"
 
-"@theia/ovsx-client@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.28.0.tgz#e9c0ed71ad56e68f0fde96aca1490e1129c370b5"
-  integrity sha512-rtxnoe9yQNb2au4/CCfOZh5XfsspVVXLH3gpjJVHF2QISQrd3pthyo8sBJE8NssTaIjYTpq4C3usJiVX9XeZ4Q==
+"@theia/plugin-ext-vscode@1.31.0", "@theia/plugin-ext-vscode@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/plugin-ext-vscode/-/plugin-ext-vscode-1.31.0.tgz#88813c9d607e4d5fe2f02218d3e16271f01b0c5a"
+  integrity sha512-LQT5oE0TBVb7gKqCpssVeHnnHUmFNw3sWzmvBnEgxtk9vyyHmCbVoK0NvluR/pXlDDhpYlg1yPmqZgeIfUmGqw==
   dependencies:
-    "@theia/request" "1.28.0"
-    semver "^5.4.1"
-
-"@theia/plugin-ext-vscode@1.27.0", "@theia/plugin-ext-vscode@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/plugin-ext-vscode/-/plugin-ext-vscode-1.27.0.tgz#c48ee83c63ff4ed493556eca8008a9edb9bb7129"
-  integrity sha512-VMO8q4I2wdjVVi2lteemdsuzAxs3FBB9iXFzcbwkasOuih/WBkbL2rlo10wwKbGtxVqtbc/T6Sf6HY3HG89ciw==
-  dependencies:
-    "@theia/callhierarchy" "1.27.0"
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/navigator" "1.27.0"
-    "@theia/plugin" "1.27.0"
-    "@theia/plugin-ext" "1.27.0"
-    "@theia/terminal" "1.27.0"
-    "@theia/userstorage" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/callhierarchy" "1.31.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/navigator" "1.31.0"
+    "@theia/plugin" "1.31.0"
+    "@theia/plugin-ext" "1.31.0"
+    "@theia/terminal" "1.31.0"
+    "@theia/typehierarchy" "1.31.0"
+    "@theia/userstorage" "1.31.0"
+    "@theia/workspace" "1.31.0"
     "@types/request" "^2.0.3"
     filenamify "^4.1.0"
     request "^2.82.0"
 
-"@theia/plugin-ext@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/plugin-ext/-/plugin-ext-1.27.0.tgz#dc8bea8ceedea90a9d7fb03aa7e82e7d4d9f2125"
-  integrity sha512-7nq7vU0x1hHAYdhg4rrtPL4njq7+4Zqud1exPZLfX8qtvF3bWaAEtUuV5b4eMyiweSwaO/7zWGzLWkQ5PkTrcQ==
+"@theia/plugin-ext@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/plugin-ext/-/plugin-ext-1.31.0.tgz#4581c410fc879be3dc511713a78e64c03628d523"
+  integrity sha512-eNHRrHj0wOcroSCqIPwRkApuzTaScP2c/gtgtSKl10h5L8XfL+L0IOL/xm1h19OeAnv4v+zMBdCPPfw1xuVCeg==
   dependencies:
-    "@theia/bulk-edit" "1.27.0"
-    "@theia/callhierarchy" "1.27.0"
-    "@theia/console" "1.27.0"
-    "@theia/core" "1.27.0"
-    "@theia/debug" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/file-search" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/markers" "1.27.0"
-    "@theia/messages" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/navigator" "1.27.0"
-    "@theia/output" "1.27.0"
-    "@theia/plugin" "1.27.0"
-    "@theia/preferences" "1.27.0"
-    "@theia/scm" "1.27.0"
-    "@theia/search-in-workspace" "1.27.0"
-    "@theia/task" "1.27.0"
-    "@theia/terminal" "1.27.0"
-    "@theia/timeline" "1.27.0"
-    "@theia/variable-resolver" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/bulk-edit" "1.31.0"
+    "@theia/callhierarchy" "1.31.0"
+    "@theia/console" "1.31.0"
+    "@theia/core" "1.31.0"
+    "@theia/debug" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/file-search" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/markers" "1.31.0"
+    "@theia/messages" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/navigator" "1.31.0"
+    "@theia/output" "1.31.0"
+    "@theia/plugin" "1.31.0"
+    "@theia/preferences" "1.31.0"
+    "@theia/scm" "1.31.0"
+    "@theia/search-in-workspace" "1.31.0"
+    "@theia/task" "1.31.0"
+    "@theia/terminal" "1.31.0"
+    "@theia/timeline" "1.31.0"
+    "@theia/typehierarchy" "1.31.0"
+    "@theia/variable-resolver" "1.31.0"
+    "@theia/workspace" "1.31.0"
     "@types/mime" "^2.0.1"
+    "@vscode/debugprotocol" "^1.51.0"
     decompress "^4.2.1"
     escape-html "^1.0.3"
     filenamify "^4.1.0"
@@ -1623,191 +1628,192 @@
     semver "^5.4.1"
     uuid "^8.0.0"
     vhost "^3.0.2"
-    vscode-debugprotocol "^1.32.0"
     vscode-proxy-agent "^0.11.0"
-    vscode-textmate "^4.0.1"
+    vscode-textmate "7.0.1"
 
-"@theia/plugin@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/plugin/-/plugin-1.27.0.tgz#0d9a720766a6eaf9841ba11f377ebde459afaf6a"
-  integrity sha512-1VAx8Aa3qHinTt1XixkzUUy3lh0bOBBKPbIdwmEN3Pd1//Ls8m46bwtAqGL9HKflEWEFb3OBcrvNuNmAZ6F+kw==
+"@theia/plugin@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/plugin/-/plugin-1.31.0.tgz#ab3ed7af7c1cc4bd91ec895c36971e4b59ce4428"
+  integrity sha512-K2ClqhzSEzOQ872gNLHjVBBz/6lX21Ar6wpMbJhYA/wq+BJEitj4fDSmWO5eUcg6kA99BWOfu0uq3hshk1W3Jg==
 
-"@theia/preferences@1.27.0", "@theia/preferences@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.27.0.tgz#f316e8e8f591eef235c52538b75afda5e9a0d5a7"
-  integrity sha512-203AjU5WfTcpqc+5xZHp4aH1kAelnIrttLmgLfb3M/zYPXforYODvyOgyznBePvz6eitbcOy139r8cgXq0CCzQ==
+"@theia/preferences@1.31.0", "@theia/preferences@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.31.0.tgz#49a72252b3eff9fcd4475d71083c812e5f345acb"
+  integrity sha512-BFcrVWKxb22d+SbWB4/TxeMxZJ/2+l59QaCSNMqbQEfV+o+K/H3SIdEscQTgYAr7PvP4JuMnNVdCJGvoRh6OUA==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/userstorage" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/userstorage" "1.31.0"
+    "@theia/workspace" "1.31.0"
     async-mutex "^0.3.1"
     jsonc-parser "^2.2.0"
     p-debounce "^2.1.0"
 
-"@theia/preview@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/preview/-/preview-1.27.0.tgz#77cc65deb0b7841c3cc0f3d17896dc6ed7adf235"
-  integrity sha512-tOJLwsL1J3/3pkVRfa+AMnPxhhaMUNCq0WBapvGq8iXo4RzmmK0PTRxKXG60KjrWVhuw0cRXm0+dljWzT+JXJA==
+"@theia/preview@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/preview/-/preview-1.31.0.tgz#86b00d2499c7e548d3d1a794dd3a2881490b660b"
+  integrity sha512-3g1jM4XUEcPZ8vXdUVbkyz+3qlH9LGogLKlpgruRCeYMH1JLXBF4bRqwHIliubJxGd0ROqgYG+GEj2iJXJI8tQ==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/mini-browser" "1.27.0"
-    "@theia/monaco" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/mini-browser" "1.31.0"
+    "@theia/monaco" "1.31.0"
     "@types/highlight.js" "^10.1.0"
     "@types/markdown-it-anchor" "^4.0.1"
     highlight.js "10.4.1"
     markdown-it-anchor "~5.0.0"
 
-"@theia/process@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.27.0.tgz#f71b3c851958c390951dee26b79e3769fd273b28"
-  integrity sha512-zBkOn/u7aGzwulp+41ZfYxZWQ2TjsXEK+OCmJK3iaDPvjm6td32oazEz6OJdMESsuXh4t/5Rig9pqQOwnh0FYQ==
+"@theia/process@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.31.0.tgz#d362e3a5d6173127dfd6104f6011bc7672bfc957"
+  integrity sha512-COe/ZIoFhFrKJOn/j0dPSUwXION6scw5jRZDAMqsI3+1tsbYp3y5O6Y+F2c+jOTybBr69SFagPATSNUtfXWznw==
   dependencies:
-    "@theia/core" "1.27.0"
+    "@theia/core" "1.31.0"
     node-pty "0.11.0-beta17"
     string-argv "^0.1.1"
 
-"@theia/request@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.27.0.tgz#0432dc0ca73454b79c74ca468936ac7d3d16116a"
-  integrity sha512-Hxkg9CVL466jgFhsSQ0eCRI4uBPPcTJtxgGSbDIwtJaabYtVsboKPmiyepZcHCAoN5dSIPfd9lUnsa8PpOLjlQ==
+"@theia/request@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.31.0.tgz#6fbebddd5eb15df640e4ef8df94696261eb7222c"
+  integrity sha512-+gBLInE7A1BAE7ndj9QhtliixbFvEdOWKcfaWHGXlornyh/v1ntUEuBDpL4h8UuGxTtXn2lws0w/HcxekkjSlg==
   dependencies:
     http-proxy-agent "^5.0.0"
     https-proxy-agent "^5.0.0"
 
-"@theia/request@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.28.0.tgz#2cf1fc9eec19ea9357449867f04efe8458b37e64"
-  integrity sha512-Cq8WiMDzby5HNSf0o3l+9bIfHSlQ4sa1rPfFXR21VqByutstOHBgDQNMqu/QtLXsSWd1YNoPbDfTlO7fhDuD5w==
+"@theia/scm-extra@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/scm-extra/-/scm-extra-1.31.0.tgz#f1903ebb4270685fb1af27a9d828352d4d6517b3"
+  integrity sha512-xSor1fDqzfA+T0VUUkjZGbMp+LC7ozYKUClSn02TtUKAoQ76EIg9SbicekcRjkPtAPvII7ThFkq3lkKxGlCUeQ==
   dependencies:
-    http-proxy-agent "^5.0.0"
-    https-proxy-agent "^5.0.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/navigator" "1.31.0"
+    "@theia/scm" "1.31.0"
 
-"@theia/scm-extra@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/scm-extra/-/scm-extra-1.27.0.tgz#e2f76ec2e7817ff7d24918a2f298038b03468485"
-  integrity sha512-umFbUagqyhV42fJLn2SAjM00wrUfkmjo08S0OOF2Y9Lkaq6suu7Bvs7+EWaDcuxnkT6p2KSFvwnv2XACzsdiRw==
+"@theia/scm@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/scm/-/scm-1.31.0.tgz#39954f6e51f9025565849d465bf6952e7f5933d1"
+  integrity sha512-z91yJ//CntxbHVWvT/UqcbujFLm3IZQ0xGxUWE/cN5ZUuN99inyCKDzsc/iMHdsWLCsacG31xhr/WKxUpWbs0A==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/navigator" "1.27.0"
-    "@theia/scm" "1.27.0"
-
-"@theia/scm@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/scm/-/scm-1.27.0.tgz#db3abf00ac472a58db9e20d6562e0c6661a31bb9"
-  integrity sha512-IJKV+LWbXQrSfIARg0DUeROPmEvjoT3l0/kCFBvIjrpGufqipNIAvHuDOMWFAYCD3kYSb4NCdIQhXJVOoFXmgw==
-  dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
     "@types/diff" "^3.2.2"
     diff "^3.4.0"
     p-debounce "^2.1.0"
     react-autosize-textarea "^7.0.0"
     ts-md5 "^1.2.2"
 
-"@theia/search-in-workspace@1.27.0", "@theia/search-in-workspace@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/search-in-workspace/-/search-in-workspace-1.27.0.tgz#75410acfb6f6b5396c9cbbb561ac7b57f6bbb9c1"
-  integrity sha512-bMWbsR8sYH3+W3DCDGFv12sy3BFCUnsPigZrAsYRcIynfLUg+MhZiBpikQCiDhCqry1sobFEOjO1tzuY5BdLcg==
+"@theia/search-in-workspace@1.31.0", "@theia/search-in-workspace@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/search-in-workspace/-/search-in-workspace-1.31.0.tgz#46524765365d823d626c7480dc0eda6fb800b6b9"
+  integrity sha512-j0SsC9JftrBTBUG6bERjCw0zkC/gmdgkjZdjZve3qb5LOUwmSrqI0D/Y30tbeZya6YzZnYGn6najoC4ndZ9Vqw==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/navigator" "1.27.0"
-    "@theia/process" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/navigator" "1.31.0"
+    "@theia/process" "1.31.0"
+    "@theia/workspace" "1.31.0"
+    "@vscode/ripgrep" "^1.14.2"
     minimatch "^3.0.4"
-    vscode-ripgrep "^1.2.4"
 
-"@theia/task@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/task/-/task-1.27.0.tgz#0cabd212829f7672df7a42ed02020fcef2646f9b"
-  integrity sha512-n9c43IV4XN+bo77F9AwRHbSuxKGxMxUB2dEaQZzvgCb9hSJ6vDgpmfeeYVcwQNoz18MO9SgDk2x4A8h9XWPv/g==
+"@theia/task@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/task/-/task-1.31.0.tgz#767ed953bc20608abe26c6e51415c29b3405a370"
+  integrity sha512-VxfbCmrhe1aTRPjVZ7HBkO4KwNrsegR/rbUDn6H4vl9K7FdTMFXjXIuXyXLtmiIaSPMsUttuu73LprgO7fmUOQ==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/markers" "1.27.0"
-    "@theia/monaco" "1.27.0"
-    "@theia/monaco-editor-core" "1.65.2"
-    "@theia/process" "1.27.0"
-    "@theia/terminal" "1.27.0"
-    "@theia/userstorage" "1.27.0"
-    "@theia/variable-resolver" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/markers" "1.31.0"
+    "@theia/monaco" "1.31.0"
+    "@theia/monaco-editor-core" "1.67.2"
+    "@theia/process" "1.31.0"
+    "@theia/terminal" "1.31.0"
+    "@theia/userstorage" "1.31.0"
+    "@theia/variable-resolver" "1.31.0"
+    "@theia/workspace" "1.31.0"
     async-mutex "^0.3.1"
     jsonc-parser "^2.2.0"
     p-debounce "^2.1.0"
 
-"@theia/terminal@1.27.0", "@theia/terminal@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.27.0.tgz#e174c1140ccc6744615ff0eef4ffdf14f3097b06"
-  integrity sha512-0ZlkAX6h2swGhX8AEoZly8V3gv+vyZz3x00l+K8UVGIRg/W/p/KSzOzW9aU1tn8igOcFL/rtjQVYSBwDjsEv9g==
+"@theia/terminal@1.31.0", "@theia/terminal@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.31.0.tgz#171db83ddae09d82cf98f16677aa528e6c359619"
+  integrity sha512-SU230s/UnAAENQ/sqotlzGsg3dZwYTMBVoLCX8lfm4UNN0cl7nz6plYLQtjXb+ZKI9II5TyJukWiI5PPIHKBDQ==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/editor" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/process" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/process" "1.31.0"
+    "@theia/workspace" "1.31.0"
     xterm "^4.16.0"
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.2"
 
-"@theia/timeline@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/timeline/-/timeline-1.27.0.tgz#dc365db88170f62fca7b69eb52fd8a3b18cefe60"
-  integrity sha512-ptjXCgiF+o4FveDCkPvsAAzdaqcZbtDZZN+gkXbP8h+DBzRIPQ1Dup4YaByTTG17QJUe8q7NBV2KLt5Tk0wCtA==
+"@theia/timeline@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/timeline/-/timeline-1.31.0.tgz#4bbeafc6ae76fc0650b4dd05fde1d04551c5bf5e"
+  integrity sha512-OqaOTdJ9UeX0L8PxMyF48joyoTk4sedmb22NoY6vRkdzuMFD4VVsSfkJ3Mj1sT6iu1oNUeuxHRuRjuw2iVjLtA==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/navigator" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/navigator" "1.31.0"
 
-"@theia/userstorage@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.27.0.tgz#94ef58ac144811a3f59b70917c049bab9b743c5d"
-  integrity sha512-C2L9+NtDIARB+LxxIwx4gYWrVFXXy1t1H5w++FHXfkQn9s2NYzXnVsJpLNBJNudEuD7l7QctLv/kJIYEc9M27Q==
+"@theia/typehierarchy@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/typehierarchy/-/typehierarchy-1.31.0.tgz#c9d1f73a1774e7f9164c8a99b0ad7a19d0c1a3ea"
+  integrity sha512-skFhx5IBbTLMtveU2oDGYFmann6ftXPiHUwMubMEBBOs0E5E7QS0mq1YcKlJXwTP8XVvAS6ObbljZ6+UUC3hFg==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/filesystem" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/editor" "1.31.0"
+    "@types/uuid" "^7.0.3"
+    uuid "^8.0.0"
 
-"@theia/variable-resolver@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.27.0.tgz#50c35919671c75ed5144bdebeab8d36d1eaf655d"
-  integrity sha512-LEPTe2t2P0hhnrXC0pSgBMcMVU4L7YhaQfUiRsSwHaWPW+VuM7hluVN1098nRO3TNnPPnYoOqh0fmBnSKfUMaQ==
+"@theia/userstorage@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.31.0.tgz#1344b262ee8dd5c5728202400e557b8cf2541c61"
+  integrity sha512-HFbquZ1kP/VgSYZ0k7ADHpX986TgRb2pwWL950JQIeQ9PudKv9RmGG9VQ38+ObV0ntwjyDb0YGGBk78HntdRxw==
   dependencies:
-    "@theia/core" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/filesystem" "1.31.0"
 
-"@theia/vsx-registry@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/vsx-registry/-/vsx-registry-1.27.0.tgz#f2dbf82cf81f88f07f308d2e2401208881648cab"
-  integrity sha512-a97mT6odiDPAyNa/lqqvw9W6nEqx5NmoD1Ls6bD1dcNJQ3uQNRPLYft910AsIQGFbyr23WfeOXrnOsz+G58wyA==
+"@theia/variable-resolver@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.31.0.tgz#fdedd12e9a22abebdcc6d5daeb8828e1ce3e3864"
+  integrity sha512-F5Mwt2/BTYA8P1Fmd0Ad9pkJ/4UgsbTeLuaIqF1/+9zEwprGklL1obgffBAO6ifTyu2V5tX0lMKuYBG/7m65pg==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/ovsx-client" "1.27.0"
-    "@theia/plugin-ext" "1.27.0"
-    "@theia/plugin-ext-vscode" "1.27.0"
-    "@theia/preferences" "1.27.0"
-    "@theia/workspace" "1.27.0"
+    "@theia/core" "1.31.0"
+
+"@theia/vsx-registry@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/vsx-registry/-/vsx-registry-1.31.0.tgz#e7725f203b2ebc1712df3cbe04fba6436310238f"
+  integrity sha512-AoOfxgXum49N68p0mM40PPCiDvwXfsF4VhTSGQl2Kfv3Z/9MFdlM9SyaraVk0MtY4HNO2rnv29PrQ5cFgolsUg==
+  dependencies:
+    "@theia/core" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/ovsx-client" "1.31.0"
+    "@theia/plugin-ext" "1.31.0"
+    "@theia/plugin-ext-vscode" "1.31.0"
+    "@theia/preferences" "1.31.0"
+    "@theia/workspace" "1.31.0"
     luxon "^2.4.0"
     p-debounce "^2.1.0"
     semver "^5.4.1"
     uuid "^8.0.0"
 
-"@theia/workspace@1.27.0":
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.27.0.tgz#070d0c632bf80191b85c107b8dded3e6a2b5c31e"
-  integrity sha512-qMMJkKTOua1uSA2RltAvQTCweD4uLKlT7aBhucZYYu0Q2FoMZnImMcruX7Bw7F5YB1URJAoUhVt7o6tJ5qKv7w==
+"@theia/workspace@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.31.0.tgz#54a9bc344fd8694b1209a8a4c1216f4a203bb78d"
+  integrity sha512-frHkLiuBXgnWW09Zhx9bNMmgcjs6C+/OKd88xt/YjH2ibPHYgl0KvgH7MkaQxcTACFd3TWFsn4nA1OMvP8LYCg==
   dependencies:
-    "@theia/core" "1.27.0"
-    "@theia/filesystem" "1.27.0"
-    "@theia/variable-resolver" "1.27.0"
+    "@theia/core" "1.31.0"
+    "@theia/filesystem" "1.31.0"
+    "@theia/variable-resolver" "1.31.0"
     jsonc-parser "^2.2.0"
     valid-filename "^2.0.1"
 
@@ -1855,11 +1861,6 @@
   version "4.2.22"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.22.tgz#47020d7e4cf19194d43b5202f35f75bd2ad35ce7"
   integrity sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==
-
-"@types/component-emitter@^1.2.10":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.11.tgz#50d47d42b347253817a39709fef03ce66a108506"
-  integrity sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==
 
 "@types/connect@*":
   version "3.4.35"
@@ -2105,34 +2106,17 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^16.8.0":
-  version "16.9.16"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.16.tgz#c591f2ed1c6f32e9759dfa6eb4abfd8041f29e39"
-  integrity sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==
+"@types/react-dom@^18.0.6":
+  version "18.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.8.tgz#d2606d855186cd42cc1b11e63a71c39525441685"
+  integrity sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "*"
 
-"@types/react-virtualized@^9.18.3":
-  version "9.21.21"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.21.tgz#65c96f25314f0fb3d40536929dc78112753b49e1"
-  integrity sha512-Exx6I7p4Qn+BBA1SRyj/UwQlZ0I0Pq7g7uhAp0QQ4JWzZunqEqNBGTmCmMmS/3N9wFgAGWuBD16ap7k8Y14VPA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/react" "^17"
-
-"@types/react@^16", "@types/react@^16.8.0":
-  version "16.14.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.28.tgz#073258f3fe7bb80c748842c1f93aeaafe16dffad"
-  integrity sha512-83zBE6+XUVXsdL3iFzOyUewdauaU+KviKCHEGOgSW52coAuqW7tEKQM0E9+ZC0Zk6TELQ2/JgogPvp7FavzFwg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17":
-  version "17.0.47"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
-  integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
+"@types/react@*", "@types/react@^18.0.15":
+  version "18.0.24"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
+  integrity sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2258,10 +2242,35 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@virtuoso.dev/react-urx@^0.2.12":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.13.tgz#e2cfc42d259d2a002695e7517d34cb97b64ee9c4"
+  integrity sha512-MY0ugBDjFb5Xt8v2HY7MKcRGqw/3gTpMlLXId2EwQvYJoC8sP7nnXjAxcBtTB50KTZhO0SbzsFimaZ7pSdApwA==
+  dependencies:
+    "@virtuoso.dev/urx" "^0.2.13"
+
+"@virtuoso.dev/urx@^0.2.12", "@virtuoso.dev/urx@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/urx/-/urx-0.2.13.tgz#a65e7e8d923cb03397ac876bfdd45c7f71c8edf1"
+  integrity sha512-iirJNv92A1ZWxoOHHDYW/1KPoi83939o83iUBQHIim0i3tMeSKEh+bxhJdTHQ86Mr4uXx9xGUTq69cp52ZP8Xw==
+
 "@vscode/codicons@*":
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.31.tgz#1dc56f9442c3928b1c851965cf360e7e051e6511"
   integrity sha512-fldpXy7pHsQAMlU1pnGI23ypQ6xLk5u6SiABMFoAmlj4f2MR0iwg7C19IB1xvAEGG+dkxOfRSrbKF8ry7QqGQA==
+
+"@vscode/debugprotocol@^1.51.0":
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.57.0.tgz#f055c0422b1f77358a12b1415623099ba0541647"
+  integrity sha512-eww0WhAtj3lPX7+7tGkxQ3P7IRC3hS7+SVL7fmM8CAat2DMM+PVjg1FQbTCtMw6EwNSmT/qMx1iZCyzQguJJKA==
+
+"@vscode/ripgrep@^1.14.2":
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.14.2.tgz#47c0eec2b64f53d8f7e1b5ffd22a62e229191c34"
+  integrity sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    proxy-from-env "^1.1.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -2517,6 +2526,13 @@ ansi-colors@3.2.3:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
 
+ansi-escapes@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -2650,6 +2666,11 @@ ast-types@^0.9.2:
   version "0.9.14"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.14.tgz#d34ba5dffb9d15a44351fd2a9d82e4ab2838b5ba"
   integrity sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw==
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-limiter@~1.0.0:
   version "1.0.1"
@@ -2858,6 +2879,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -2985,19 +3013,6 @@ cacheable-lookup@^5.0.3:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
   integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
-
-cacheable-request@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
-  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
-  dependencies:
-    clone-response "^1.0.2"
-    get-stream "^5.1.0"
-    http-cache-semantics "^4.0.0"
-    keyv "^3.0.0"
-    lowercase-keys "^2.0.0"
-    normalize-url "^4.1.0"
-    responselike "^1.0.2"
 
 cacheable-request@^7.0.2:
   version "7.0.2"
@@ -3196,11 +3211,6 @@ clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-clsx@^1.0.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -3262,11 +3272,6 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-emitter@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 compress-brotli@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/compress-brotli/-/compress-brotli-1.3.8.tgz#0c0a60c97a989145314ec381e84e26682e7b38db"
@@ -3302,14 +3307,6 @@ concat-stream@^1.5.2, concat-stream@^1.6.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-config-chain@^1.1.11:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
-  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
-  dependencies:
-    ini "^1.3.4"
-    proto-list "~1.2.1"
 
 console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -3500,13 +3497,6 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decompress-response@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
-  integrity sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==
-  dependencies:
-    mimic-response "^1.0.0"
-
 decompress-response@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
@@ -3598,11 +3588,6 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-defer-to-connect@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
-  integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
-
 defer-to-connect@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
@@ -3674,14 +3659,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dom-helpers@^5.1.3:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
-
 dompurify@^2.2.9:
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.9.tgz#a4be5e7278338d6db09922dffcf6182cd099d70a"
@@ -3697,10 +3674,10 @@ drivelist@^9.0.2:
     nan "^2.14.0"
     prebuild-install "^5.2.4"
 
-dugite-extra@0.1.15:
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.1.15.tgz#322406b628ea5515c5c6fcd65e4d040543d6268a"
-  integrity sha512-beLmQcIXLA8aXqWQZF/ooECoZvYKpBywIFwgqAoYnV04NdWUXDtZ6mMcjQf5eAz5PjXGXAYSuQ31zkPL8J85+A==
+dugite-extra@0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.1.16.tgz#cc1f48e1090c8e8507ff7fe342e9af8b7bb4e9ed"
+  integrity sha512-Fcl+o0hZy7dwuI4vIxNLYpEsYeYRSEAQDshyiikX3WMJMOj0JZQ6Qt0H3PtlOdJYGUZocGGZ8VFRtbJeCT24lw==
   dependencies:
     byline "^5.0.0"
     dugite-no-gpl "1.69.0"
@@ -3725,11 +3702,6 @@ duplexer2@~0.1.4:
   integrity sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==
   dependencies:
     readable-stream "^2.0.2"
-
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==
 
 duplexer@~0.1.1:
   version "0.1.2"
@@ -3789,7 +3761,7 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-encodeurl@^1.0.2, encodeurl@~1.0.2:
+encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
@@ -4121,7 +4093,7 @@ fast-glob@^3.1.1, fast-glob@^3.2.5:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -4471,13 +4443,6 @@ get-stream@^2.2.0:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
 
-get-stream@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
-  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
-
 get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
@@ -4570,6 +4535,17 @@ glob@^7.1.4, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 global-agent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz#ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6"
@@ -4581,16 +4557,6 @@ global-agent@^3.0.0:
     roarr "^2.15.3"
     semver "^7.3.2"
     serialize-error "^7.0.1"
-
-global-tunnel-ng@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz#d03b5102dfde3a69914f5ee7d86761ca35d57d8f"
-  integrity sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==
-  dependencies:
-    encodeurl "^1.0.2"
-    lodash "^4.17.10"
-    npm-conf "^1.1.3"
-    tunnel "^0.0.6"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -4628,7 +4594,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-got@^11.7.0:
+got@^11.7.0, got@^11.8.5:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -4644,23 +4610,6 @@ got@^11.7.0:
     lowercase-keys "^2.0.0"
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
-
-got@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
-  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
-  dependencies:
-    "@sindresorhus/is" "^0.14.0"
-    "@szmarczak/http-timer" "^1.1.2"
-    cacheable-request "^6.0.0"
-    decompress-response "^3.3.0"
-    duplexer3 "^0.1.4"
-    get-stream "^4.1.0"
-    lowercase-keys "^1.0.1"
-    mimic-response "^1.0.1"
-    p-cancelable "^1.0.0"
-    to-readable-stream "^1.0.0"
-    url-parse-lax "^3.0.0"
 
 graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
   version "4.2.10"
@@ -4923,7 +4872,7 @@ inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4, ini@~1.3.0:
+ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -5217,11 +5166,6 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-json-buffer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
-  integrity sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==
-
 json-buffer@3.0.1, json-buffer@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -5304,13 +5248,6 @@ keytar@7.2.0:
   dependencies:
     node-addon-api "^3.0.0"
     prebuild-install "^6.0.0"
-
-keyv@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
-  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
-  dependencies:
-    json-buffer "3.0.0"
 
 keyv@^4.0.0:
   version "4.3.2"
@@ -5413,7 +5350,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@^4.17.10, lodash@^4.17.15:
+lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5433,17 +5370,22 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lowercase-keys@^2.0.0:
   version "2.0.0"
@@ -5457,13 +5399,6 @@ lru-cache@^4.0.0:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -5640,7 +5575,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-response@^1.0.0, mimic-response@^1.0.1:
+mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
@@ -5655,6 +5590,13 @@ mimic-response@^3.1.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
+mini-css-extract-plugin@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz#9a1251d15f2035c342d99a468ab9da7a0451b71e"
+  integrity sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==
+  dependencies:
+    schema-utils "^4.0.0"
+
 minimatch@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -5668,6 +5610,13 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
@@ -5835,6 +5784,27 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msgpackr-extract@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz#56272030f3e163e1b51964ef8b1cd5e7240c03ed"
+  integrity sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==
+  dependencies:
+    node-gyp-build-optional-packages "5.0.3"
+  optionalDependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "2.1.2"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "2.1.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "2.1.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "2.1.2"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "2.1.2"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "2.1.2"
+
+msgpackr@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.7.2.tgz#68d6debf5999d6b61abb6e7046a689991ebf7261"
+  integrity sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==
+  optionalDependencies:
+    msgpackr-extract "^2.1.2"
+
 multer@1.4.4-lts.1:
   version "1.4.4-lts.1"
   resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.4-lts.1.tgz#24100f701a4611211cfae94ae16ea39bb314e04d"
@@ -5933,6 +5903,11 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
+node-gyp-build-optional-packages@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz#92a89d400352c44ad3975010368072b41ad66c17"
+  integrity sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==
+
 node-gyp-build@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.4.0.tgz#42e99687ce87ddeaf3a10b99dc06abc11021f3f4"
@@ -5983,23 +5958,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-normalize-url@^4.1.0:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
-  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
-
 normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
-
-npm-conf@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
-  integrity sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==
-  dependencies:
-    config-chain "^1.1.11"
-    pify "^3.0.0"
 
 npm-run-path@^1.0.0:
   version "1.0.0"
@@ -6129,20 +6091,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-onigasm@^2.2.0:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
-  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
-  dependencies:
-    lru-cache "^5.1.1"
-
-oniguruma@^7.2.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.3.tgz#e0b0b415302de8cdd6564e57a1a822ac0ab57012"
-  integrity sha512-PZZcE0yfg8Q1IvaJImh21RUTHl8ep0zwwyoE912KqlWVrsGByjjj29sdACcD1BFyX2bLkfuOJeP+POzAGVWtbA==
-  dependencies:
-    nan "^2.14.0"
-
 optimist@~0.3.5:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
@@ -6169,11 +6117,6 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==
-
-p-cancelable@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
-  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -6475,11 +6418,6 @@ prebuild-install@^6.0.0:
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
 
-prepend-http@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
-  integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
-
 private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6508,7 +6446,7 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
-prop-types@^15.5.6, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.6, prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6516,11 +6454,6 @@ prop-types@^15.5.6, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-proto-list@~1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
-  integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -6674,25 +6607,18 @@ react-autosize-textarea@^7.0.0:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
-react-dom@^16.8.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.23.0"
 
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-perfect-scrollbar@^1.5.3:
   version "1.5.8"
@@ -6710,26 +6636,20 @@ react-tooltip@^4.2.21:
     prop-types "^15.7.2"
     uuid "^7.0.3"
 
-react-virtualized@^9.20.0:
-  version "9.22.3"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
-  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
+react-virtuoso@^2.17.0:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.19.1.tgz#a660a5c3cafcc7a84b59dfc356e1916e632c1e3a"
+  integrity sha512-zF6MAwujNGy2nJWCx/Df92ay/RnV2Kj4glUZfdyadI4suAn0kAZHB1BeI7yPFVp2iSccLzFlszhakWyr+fJ4Dw==
   dependencies:
-    "@babel/runtime" "^7.7.2"
-    clsx "^1.0.4"
-    dom-helpers "^5.1.3"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-lifecycles-compat "^3.0.4"
+    "@virtuoso.dev/react-urx" "^0.2.12"
+    "@virtuoso.dev/urx" "^0.2.12"
 
-react@^16.8.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 readable-stream@1.1.x:
   version "1.1.14"
@@ -6914,13 +6834,6 @@ resolve@^1.14.2, resolve@^1.9.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-responselike@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
-  integrity sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==
-  dependencies:
-    lowercase-keys "^1.0.0"
-
 responselike@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
@@ -7006,13 +6919,12 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^2.6.5:
   version "2.7.1"
@@ -7210,6 +7122,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -7232,21 +7153,12 @@ socket.io-client@4.4.1:
     parseuri "0.0.6"
     socket.io-parser "~4.1.1"
 
-socket.io-parser@~4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.5.tgz#cb404382c32324cc962f27f3a44058cf6e0552df"
-  integrity sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==
+socket.io-parser@~4.0.4, socket.io-parser@~4.1.1, socket.io-parser@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.1.tgz#01c96efa11ded938dcb21cbe590c26af5eff65e5"
+  integrity sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==
   dependencies:
-    "@types/component-emitter" "^1.2.10"
-    component-emitter "~1.3.0"
-    debug "~4.3.1"
-
-socket.io-parser@~4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.1.2.tgz#0a97d4fb8e67022158a568450a6e41887e42035e"
-  integrity sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==
-  dependencies:
-    "@socket.io/component-emitter" "~3.0.0"
+    "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
 socket.io@4.4.1:
@@ -7391,6 +7303,14 @@ string-argv@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.2.tgz#c5b7bc03fb2b11983ba3a72333dd0559e77e4738"
   integrity sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==
+
+string-replace-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-3.1.0.tgz#11ac6ee76bab80316a86af358ab773193dd57a4f"
+  integrity sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -7680,11 +7600,6 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
-to-readable-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
-  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
-
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -7763,11 +7678,6 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
-  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -7782,6 +7692,11 @@ type-fest@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-is@^1.6.4, type-is@~1.6.18:
   version "1.6.18"
@@ -7920,13 +7835,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse-lax@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
-  integrity sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==
-  dependencies:
-    prepend-http "^2.0.0"
-
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -7995,11 +7903,6 @@ vhost@^3.0.2:
   resolved "https://registry.yarnpkg.com/vhost/-/vhost-3.0.2.tgz#2fb1decd4c466aa88b0f9341af33dc1aff2478d5"
   integrity sha512-S3pJdWrpFWrKMboRU4dLYgMrTgoPALsmYwOvyebK2M6X95b9kQrjZy5rwl3uzzpfpENe/XrNYu/2U+e7/bmT5g==
 
-vscode-debugprotocol@^1.32.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.51.0.tgz#c03168dac778b6c24ce17b3511cb61e89c11b2df"
-  integrity sha512-dzKWTMMyebIMPF1VYMuuQj7gGFq7guR8AFya0mKacu+ayptJfaRuM0mdHCqiOth4FnRP8mPhEroFPx6Ift8wHA==
-
 vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
@@ -8023,6 +7926,11 @@ vscode-languageserver-types@3.15.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
+vscode-oniguruma@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz#2bf4dfcfe3dd2e56eb549a3068c8ee39e6c30ce5"
+  integrity sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==
+
 vscode-proxy-agent@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/vscode-proxy-agent/-/vscode-proxy-agent-0.11.0.tgz#9dc8d2bb9d448f1e33bb1caef97a741289660f2f"
@@ -8038,20 +7946,10 @@ vscode-proxy-agent@^0.11.0:
   optionalDependencies:
     vscode-windows-ca-certs "^0.3.0"
 
-vscode-ripgrep@^1.2.4:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.13.2.tgz#8ccebc33f14d54442c4b11962aead163c55b506e"
-  integrity sha512-RlK9U87EokgHfiOjDQ38ipQQX936gWOcWPQaJpYf+kAkz1PQ1pK2n7nhiscdOmLu6XGjTs7pWFJ/ckonpN7twQ==
-  dependencies:
-    https-proxy-agent "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-vscode-textmate@^4.0.1, vscode-textmate@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.4.0.tgz#14032afeb50152e8f53258c95643e555f2948305"
-  integrity sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==
-  dependencies:
-    oniguruma "^7.2.0"
+vscode-textmate@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-7.0.1.tgz#8118a32b02735dccd14f893b495fa5389ad7de79"
+  integrity sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==
 
 vscode-uri@^2.1.1:
   version "2.1.2"
@@ -8342,7 +8240,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
+yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Looks like a transitive dependency that is locked to an earlier version, so forcing the upgrade

DT-772