### PR TITLE
feat: move to RStudio 4 in v4 Dockerfile

### DIFF
--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -29,7 +29,7 @@ RUN \
 		ca-certificates \
 		dirmngr \
 		gnupg2 && \
-	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran40/" >> /etc/apt/sources.list && \
 	until apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'; do sleep 10; done && \
 	apt-get clean -y && \
 	apt-get autoremove -y && \
@@ -38,34 +38,27 @@ RUN \
 	rm -rf /var/lib/apt/lists/* && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		gdebi-core=0.9.5.7+nmu3 \
-		gfortran=4:8.3.0-1 \
-		git=1:2.20.1-2+deb10u3 \
-		libgit2-dev=0.27.7+dfsg.1-0.2 \
-		libgsl-dev=2.5+dfsg-6 \
+		gdebi-core \
+		gfortran \
+		git \
+		libgit2-dev \
+		libgsl-dev \
 		libxml2-dev \
 		libpq-dev \
 		libgdal-dev \
-		lmodern=2.004.5-6 \
-		procps=2:3.3.15-2 \
-		r-base-dev=3.6.1-2~bustercran.0 \
-		r-base=3.6.1-2~bustercran.0 \
-		r-cran-base64enc=0.1-3-2 \
-		r-cran-curl=3.3+dfsg-1 \
-		r-cran-data.table=1.12.0+dfsg-1 \
-		r-cran-dbi=1.0.0-2 \
-		r-cran-httr=1.4.0-3 \
-		r-cran-rpostgresql=0.6-2+dfsg-2 \
-		r-cran-xml2=1.2.0-3 \
-		r-recommended=3.6.1-2~bustercran.0 \
-		ssh=1:7.9p1-10+deb10u2 \
-		texlive=2018.20190227-2 \
-		texlive-latex-extra=2018.20190227-2 \
-		git-man=1:2.20.1-2+deb10u3 \
+		lmodern \
+		procps \
+		r-base-dev \
+		r-base \
+		r-recommended \
+		ssh \
+		texlive \
+		texlive-latex-extra \
+		git-man \
 		man-db=2.8.5-2 \
                 vim \
                 emacs \
-		wget=1.20.1-1.1 && \
+		wget && \
 	wget -q https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5019-amd64.deb && \
 	echo "bfea9b32c04b721d5d2fb29be510b4378d57a6cd6c8c0dc8390b8760a87341b3  rstudio-server-1.2.5019-amd64.deb" | sha256sum -c && \
 	gdebi --non-interactive rstudio-server-1.2.5019-amd64.deb && \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -29,7 +29,7 @@ RUN \
 		ca-certificates \
 		dirmngr \
 		gnupg2 && \
-	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran40/" >> /etc/apt/sources.list && \
 	until apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'; do sleep 10; done && \
 	apt-get clean -y && \
 	apt-get autoremove -y && \


### PR DESCRIPTION
This unpins various packages, but we're still pinned to a major Debian version as well as v4 of R. I think this is probably good enough - pinning Debian packages more strongly tends to just give pain without I think much of a benefit.