### PR TITLE
fix: remove theia and jupyterhub full access to directory

### DIFF
--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -59,7 +59,7 @@ RUN \
     groupadd -g 4356 jovyan && \
     useradd -u 4357 jovyan -g jovyan -m && \
     echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
-    echo "jovyan ALL=NOPASSWD:/usr/local/bin/dw-install" >> /etc/sudoers && \
+    echo "jovyan ALL=NOPASSWD:/usr/bin/dw-install" >> /etc/sudoers && \
     wget -q -O - https://deb.nodesource.com/setup_14.x | bash  && \
     apt-get install -y nodejs && \
     apt-get remove --purge -y \
@@ -97,6 +97,7 @@ RUN \
 RUN \
     /root/python-setup.sh && \
     jupyter lab build && \
+    chown -R jovyan:jovyan /usr/local && \
     chown -R jovyan:jovyan /opt/conda
 
 COPY jupyterlab-python/jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -97,7 +97,6 @@ RUN \
 RUN \
     /root/python-setup.sh && \
     jupyter lab build && \
-    chown -R jovyan:jovyan /usr/local && \
     chown -R jovyan:jovyan /opt/conda
 
 COPY jupyterlab-python/jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
@@ -123,8 +122,8 @@ RUN \
     echo 'PS1="\w\\\\$ \[$(tput sgr0)\]"' >> /etc/bash.bashrc && \
     rm /home/jovyan/.bashrc
 
-COPY dw-install /usr/local/bin/dw-install
-COPY glfsm /usr/local/bin/glfsm
+COPY dw-install /usr/bin/dw-install
+COPY glfsm /usr/bin/glfsm
 COPY jupyterlab-python/start.sh /
 
 CMD ["/start.sh"]

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -118,10 +118,10 @@ RUN \
 	# Avoids errors when installing Java
 	mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 && \
 	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
-	echo "rstudio ALL=NOPASSWD:/usr/local/bin/dw-install" >> /etc/sudoers && \
+	echo "rstudio ALL=NOPASSWD:/usr/bin/dw-install" >> /etc/sudoers && \
 	echo 'PS1="\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
 	rm /home/rstudio/.bashrc
 
-COPY dw-install /usr/local/bin/dw-install
+COPY dw-install /usr/bin/dw-install
 
 CMD ["/rstudio-start.sh"]

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -110,10 +110,10 @@ RUN \
 	# Avoids errors when installing Java
 	mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 && \
 	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
-	echo "rstudio ALL=NOPASSWD:/usr/local/bin/dw-install" >> /etc/sudoers && \
+	echo "rstudio ALL=NOPASSWD:/usr/bin/dw-install" >> /etc/sudoers && \
 	echo 'PS1="\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
 	rm /home/rstudio/.bashrc
 
-COPY dw-install /usr/local/bin/dw-install
+COPY dw-install /usr/bin/dw-install
 
 CMD ["/rstudio-start.sh"]

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -74,7 +74,6 @@ RUN \
 
 RUN \
     /root/python-setup.sh && \
-    chown -R theia:theia /usr/local && \
     chown -R theia:theia /opt/conda
 
 WORKDIR /root

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -108,8 +108,8 @@ RUN \
 	mkdir /certs
 
 COPY rds-global-bundle.pem /certs/rds-global-bundle.pem
-COPY dw-install /usr/local/bin/dw-install
-COPY glfsm /usr/local/bin/glfsm
+COPY dw-install /usr/bin/dw-install
+COPY glfsm /usr/bin/glfsm
 COPY theia/vscode_postgres.theia /root/plugins/vscode_postgres.theia
 COPY theia/start.sh /start.sh
 

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -100,7 +100,7 @@ RUN \
 	touch /root/yarn-error.log && \
 	chown theia:theia /root/yarn-error.log && \
 	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
-	echo "theia ALL=NOPASSWD:/usr/local/bin/dw-install" >> /etc/sudoers && \
+	echo "theia ALL=NOPASSWD:/usr/bin/dw-install" >> /etc/sudoers && \
 	echo 'PS1="\w\\\\$ \[$(tput sgr0)\]"' >> /etc/bash.bashrc && \
 	rm /home/theia/.bashrc
 


### PR DESCRIPTION
Due to the moderate risk highlighted in the pen test report (9.2) the access to directory for all data workspace tools needs to be updated for both consistency and to ensure users do not have full access to the directory. The details of this report and the approach is listed below:

A review be carried out on the access control model for the affected "dw-install" binary, to ensure that users are not able to gain access to functionality they are not explicitly authorised to access.

A strong access control model helps prevent users accessing content, data or functionality for which they are not authorised. Errors in implementing the access control model could allow an attacker to perform vertical privilege escalation, where they are able to gain a higher level of access to the application than was intended, for example, a standard user gaining access to functionality of an administrator.

Recommendation from report
A review to be carried out on the access control model for the affected "dw-install" binary, to ensure that users are not able to gain access to functionality they are not explicitly authorised to access.

Comments
In Theia and JupyterLab users can obtain root privileges and then get superuser privileges.

RStudio is not affected so we may be able to learn lessons from this.

Approach taken
Updated all tools so that dw-install and glfsm lie within /usr/bin rather than /usr/local/bin to prevent user access to full directory