### PR TITLE
feat: debian pgadmin4 7.8

### DIFF
--- a/pgadmin/Dockerfile
+++ b/pgadmin/Dockerfile
@@ -1,4 +1,4 @@
-FROM dpage/pgadmin4:4.27
+FROM python:3.11.6-bullseye
 
 ENV \
 	PGADMIN_LISTEN_ADDRESS=0.0.0.0 \
@@ -6,13 +6,34 @@ ENV \
 	PGADMIN_DEFAULT_EMAIL=pgadmin4@pgadmin.org \
 	PGADMIN_DEFAULT_PASSWORD=test
 
-COPY pgadmin/pgadmin-config.py /pgadmin4/config_local.py
+USER 0
+
+RUN \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+		locales \
+        sudo && \
+	echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && \
+	locale-gen en_GB.utf8
+
+RUN pip install gunicorn pgadmin4
+
+RUN mkdir /pgadmin4 && \
+    groupadd -g 4356 pgadmin && \
+    useradd -r -u 4357 -g pgadmin -m pgadmin && \
+    mkdir -p /var/lib/pgadmin && \
+    chown pgadmin:pgadmin /var/lib/pgadmin && \
+    mkdir -p  /var/log/pgadmin && \
+    touch /var/log/pgadmin/pgadmin4.log && \
+    chown -R pgadmin:pgadmin /var/log/pgadmin && \
+    chmod g=u /var/lib/pgadmin
+
+COPY pgadmin/config_local.py /usr/local/lib/python3.11/site-packages/pgadmin4/
 COPY pgadmin/start.sh /
 
-USER root
-RUN \
-	usermod -u 4357 pgadmin && \
-	groupmod -g 4356 pgadmin && \
-	chmod +x /start.sh
+RUN python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py
+
+WORKDIR /pgadmin4
+ENV PYTHONPATH=/pgadmin4
 
 ENTRYPOINT ["/start.sh"]

--- a/pgadmin/config_local.py
+++ b/pgadmin/config_local.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import os
 import re
+import logging
 
 
 # We are running behind a proxy that handles authentication
@@ -10,6 +11,11 @@ MASTER_PASSWORD_REQUIRED = False
 
 # We don't have internet access
 UPGRADE_CHECK_ENABLED = False
+
+CONSOLE_LOG_LEVEL = logging.DEBUG
+CONSOLE_LOG_FORMAT = '%(asctime)s: %(levelname)s\t%(name)s:\t%(message)s'
+FILE_LOG_LEVEL = logging.DEBUG
+FILE_LOG_FORMAT = '%(asctime)s: %(levelname)s\t%(name)s:\t%(message)s'
 
 
 def normalise_environment(key_values):
@@ -115,7 +121,7 @@ servers = {}
 passwords = []
 passfile = "/pgadmin4/.pgpass"
 
-for i, (name, dsn) in enumerate(env["DATABASE_DSN"].items()):
+for i, (name, dsn) in enumerate(env.get("DATABASE_DSN", {}).items()):
     user = re.search(r"user=([a-z0-9_]+)", dsn).groups()[0]
     password = re.search(r"password=([a-zA-Z0-9_]+)", dsn).groups()[0]
     port = re.search(r"port=(\d+)", dsn).groups()[0]

--- a/pgadmin/start.sh
+++ b/pgadmin/start.sh
@@ -4,16 +4,13 @@ chown -R pgadmin:pgadmin /home/pgadmin
 
 set -e
 
-# Typically, we use set the owner of files/folders (not in the home directory)
-# in the Dockerfile. However, we've changed the ID of the pgadmin user,
-# and changing to the same owner but a different ID doesn't seem to get
-# properly saved when done from the Dockerfile. So, we do it here.
 touch /pgadmin4/.pgpass /pgadmin4/servers.json
 chown -R pgadmin:pgadmin \
-	/pgadmin4/config_distro.py \
 	/pgadmin4/.pgpass \
 	/pgadmin4/servers.json \
 	/var/lib/pgadmin \
 	/var/log/pgadmin
 
-sudo -E -H -u pgadmin /entrypoint.sh
+python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py --load-servers /pgadmin4/servers.json
+
+sudo -E -H -u pgadmin gunicorn --bind 0.0.0.0:8888 --workers=1 --threads=25 --chdir /usr/local/lib/python3.11/site-packages/pgadmin4 pgAdmin4:app


### PR DESCRIPTION
- Switch pgadmin to a debian backed python image as the official alpine image causes issues with our dns proxy
-  Bump pgadmin to 7.8 (from 4.27)