### PR TITLE
feat: disable dashboard from pgAdmin

### DIFF
--- a/pgadmin/Dockerfile
+++ b/pgadmin/Dockerfile
@@ -31,7 +31,16 @@ RUN mkdir /pgadmin4 && \
 COPY pgadmin/config_local.py /usr/local/lib/python3.11/site-packages/pgadmin4/
 COPY pgadmin/start.sh /
 
-RUN python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py
+# Set preferences to not show the dashboard on startup, which (at best) makes the logs of
+# what's doing on in the database really noisy, and at worst has performance implications
+# Note that we have to actually run pgadmin4 first, and only then is it possible to set preferences
+# This is because `set-prefs` depends on rows in the SQLite preference database that, as far we
+# we can tell, only get created after pgadmin4 has run properly. We don't have a way of detecting
+# if pgadmin4 has run enough to actually create the preference rows, but it really should have in
+# 20 seconds, and we only build this Docker image occasionally
+RUN \
+	(timeout 20s pgadmin4; exit 0) && \
+	python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py set-prefs pgadmin4@pgadmin.org 'dashboards:display:show_graphs=false' 'dashboards:display:show_activity=false'
 
 WORKDIR /pgadmin4
 ENV PYTHONPATH=/pgadmin4

--- a/pgadmin/start.sh
+++ b/pgadmin/start.sh
@@ -11,6 +11,6 @@ chown -R pgadmin:pgadmin \
 	/var/lib/pgadmin \
 	/var/log/pgadmin
 
-python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py --load-servers /pgadmin4/servers.json
+python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py load-servers /pgadmin4/servers.json
 
 sudo -E -H -u pgadmin gunicorn --bind 0.0.0.0:8888 --workers=1 --threads=25 --chdir /usr/local/lib/python3.11/site-packages/pgadmin4 pgAdmin4:app


### PR DESCRIPTION
 We see a lot of queries from pgAdmin's dashboard when looking at load on the database. It's hard to tell if they actually cause a problem, but turning them off by default should at least clear up a lot of noise.

This includes an increase of the version of pgAdmin just by the nature of  rebuilding with the latest version in PyPI. It's not pinned (it wasn't pinned before), but I suspect it increases the version from 7.8 to 8.3.