### PR TITLE
build(deps): bump mobius3 for code to log to CloudWatch

### DIFF
--- a/s3sync/requirements.txt
+++ b/s3sync/requirements.txt
@@ -23,7 +23,7 @@ idna==3.4
     # via
     #   anyio
     #   rfc3986
-mobius3==0.0.41
+mobius3==0.0.42
     # via -r requirements.in
 rfc3986[idna2008]==1.5.0
     # via httpx


### PR DESCRIPTION
This doesn't actually send to CloudWatch yet, but bumps to the version that can be configured to as a very small step