### PR TITLE
fix: correct conda install and activation in theia

### DIFF
--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -102,7 +102,10 @@ RUN \
 	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
 	echo "theia ALL=NOPASSWD:/usr/bin/dw-install" >> /etc/sudoers && \
 	echo 'PS1="\w\\\\$ \[$(tput sgr0)\]"' >> /etc/bash.bashrc && \
-	rm /home/theia/.bashrc
+	echo "conda activate base" >> /etc/profile && \
+	ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+	rm /home/theia/.bashrc && \
+	rm /home/theia/.profile
 
 RUN \
 	mkdir /certs


### PR DESCRIPTION
Some users seem to have a .profile in Theia and some don't, and often a .profile or a .bashrc file needs to be created before users have access to Conda. This change follows more up to date guidelines for system wide conda installs, which should result in the path being set properly, and then activates conda when theia is opened.