### PR TITLE
fixing pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -256,7 +256,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   ipympl
     #   matplotlib


### PR DESCRIPTION
Tools deployment fails with the following error
`ERROR: Ignored the following versions that require a different python version: 8.19.0 Requires-Python >=3.10; 8.20.0 Requires-Python >=3.10; 8.21.0 Requires-Python >=3.10; 8.22.0 Requires-Python >=3.10; 8.22.1 Requires-Python >=3.10; 8.22.2 Requires-Python >=3.10
09:45:19  ERROR: Could not find a version that satisfies the requirement pillow==10.3.0 (from versions: 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.7.7, 1.7.8, 2.0.0, 2.1.0, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.3.2, 2.4.0, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.8.0, 2.8.1, 2.8.2, 2.9.0, 3.0.0, 3.1.0rc1, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.4.0, 3.4.1, 3.4.2, 4.0.0, 4.1.0, 4.1.1, 4.2.0, 4.2.1, 4.3.0, 5.0.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0, 5.4.1, 6.0.0, 6.1.0, 6.2.0, 6.2.1, 6.2.2, 7.0.0, 7.1.0, 7.1.1, 7.1.2, 7.2.0, 8.0.0, 8.0.1, 8.1.0, 8.1.1, 8.1.2, 8.2.0, 8.3.0, 8.3.1, 8.3.2, 8.4.0, 9.0.0, 9.0.1, 9.1.0, 9.1.1, 9.2.0, 9.3.0, 9.4.0, 9.5.0, 10.0.0, 10.0.1, 10.1.0, 10.2.0)
09:45:19  ERROR: No matching distribution found for pillow==10.3.0`
So backtracking pillow version back to 10.2.0 until we update python version.