### PR TITLE
feat: rstudio4 on debian bullseye

### DIFF
--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:buster
+FROM debian:bullseye
 
 RUN \
-	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
-	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian-security/ buster/updates main" >> /etc/apt/sources.list && \
-	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
+	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye main" > /etc/apt/sources.list && \
+	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian-security/ bullseye/updates main" >> /etc/apt/sources.list && \
+	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye-updates main" >> /etc/apt/sources.list && \
 	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
     echo "Acquire { https::Verify-Peer false }" > /etc/apt/apt.conf.d/99verify-peer.conf && \
     apt-get update && \
@@ -30,7 +30,7 @@ RUN \
 	apt-get install -y --no-install-recommends \
 		dirmngr \
 		gnupg2 && \
-	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran40/" >> /etc/apt/sources.list && \
+	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian bullseye-cran40/" >> /etc/apt/sources.list && \
 	until apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'; do sleep 10; done && \
 	apt-get clean -y && \
 	apt-get autoremove -y && \
@@ -69,9 +69,9 @@ RUN \
 		protobuf-compiler \
 		libfribidi-dev \
 		libharfbuzz-dev \
-		man-db=2.8.5-2 \
-                vim \
-                emacs \
+		man-db \
+		vim \
+		emacs \
 		wget && \
 	wget -q https://download2.rstudio.org/server/bionic/amd64/rstudio-server-2023.03.0-386-amd64.deb && \
 	echo "8dcc6003cce4cf41fbbc0fd2c37c343311bbcbfa377d2e168245ab329df835b5  rstudio-server-2023.03.0-386-amd64.deb" | sha256sum -c && \

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye
 
 RUN \
 	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye main" > /etc/apt/sources.list && \
-	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian-security/ bullseye/updates main" >> /etc/apt/sources.list && \
+	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian-security/ bullseye-security main" >> /etc/apt/sources.list && \
 	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye-updates main" >> /etc/apt/sources.list && \
 	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
     echo "Acquire { https::Verify-Peer false }" > /etc/apt/apt.conf.d/99verify-peer.conf && \


### PR DESCRIPTION
Upgrading the rstudio-v4 base image to use debian bullseye, which would allow us to install PROJ 6.0, which would allow us to install sf > 1.0-14.