### PR TITLE
fix: pin R version to 4.3.3

### DIFF
--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -49,9 +49,9 @@ RUN \
 		libgdal-dev \
 		lmodern \
 		procps \
-		r-base-dev \
-		r-base \
-		r-recommended \
+		r-base-dev=4.3.3-2~bullseyecran.0 \
+		r-base=4.3.3-2~bullseyecran.0 \
+		r-recommended=4.3.3-2~bullseyecran.0 \
 		ssh \
 		texlive \
 		texlive-latex-extra \


### PR DESCRIPTION
Pin CRAN R version to 4.3.3 to alert future R upgrades in CRAN repo