### PR TITLE
fix: force RProfile reload when rstudio resumes suspended session

### DIFF
--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -49,9 +49,9 @@ RUN \
 		libgdal-dev \
 		lmodern \
 		procps \
-		r-base-dev=4.3.3-2~bullseyecran.0 \
-		r-base=4.3.3-2~bullseyecran.0 \
-		r-recommended=4.3.3-2~bullseyecran.0 \
+		r-base-dev=4.4.0-2~bullseyecran.0 \
+		r-base=4.4.0-2~bullseyecran.0 \
+		r-recommended=4.4.0-2~bullseyecran.0 \
 		ssh \
 		texlive \
 		texlive-latex-extra \

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -104,9 +104,10 @@ RUN \
 	echo '' >> /usr/lib/R/etc/Rprofile.site && \
 	echo 'CRAN=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/' >> /etc/rstudio/repos.conf && \
 	echo 'CRAN_1=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/' >> /etc/rstudio/repos.conf && \
+	echo 'session-rprofile-on-resume-default=1' >> /etc/rstudio/rsession.conf && \
+	echo 'session-timeout-suspend=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-timeout-minutes=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-save-action-default=no' >> /etc/rstudio/rsession.conf && \
-	echo 'session-rprofile-on-resume-default=1' >> /etc/rstudio/rsession.conf && \
 	Rscript -e 'install.packages("/exploretiva", repos=NULL, type="source")' && \
 	Rscript -e 'install.packages(c("aws.s3", "aws.ec2metadata", "ggraph", "igraph", "RPostgres", "text2vec", "tidytext", "tm", "topicmodels", "widyr", "wordcloud2", "tidyverse", "devtools", "plotly", "shiny", "leaflet", "shinydashboard", "sf", "shinycssloaders"), repos=c("https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/", "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"), clean=TRUE)'
 

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -94,7 +94,8 @@ RUN \
 	echo 'www-port=8888' >> /etc/rstudio/rserver.conf && \
 	echo 'auth-none=1' >> /etc/rstudio/rserver.conf && \
 	echo 'server-daemonize=0' >> /etc/rstudio/rserver.conf && \
-	echo 'local({' > /usr/lib/R/etc/Rprofile.site && \
+	echo 'readRenviron("/usr/lib/R/etc/Renviron.site")' > /usr/lib/R/etc/Rprofile.site && \
+	echo 'local({' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r = getOption("repos")' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/"' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN_1"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /usr/lib/R/etc/Rprofile.site && \
@@ -122,6 +123,7 @@ RUN \
 	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
 	echo "rstudio ALL=NOPASSWD:/usr/bin/dw-install" >> /etc/sudoers && \
 	echo 'PS1="\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
+	echo 'export PATH="/home/rstudio/.local/bin:$PATH"' >> /etc/bash.bashrc && \
 	rm /home/rstudio/.bashrc
 
 COPY dw-install /usr/bin/dw-install

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -103,6 +103,7 @@ RUN \
 	echo '})' >> /usr/lib/R/etc/Rprofile.site && \
 	echo 'CRAN=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/' >> /etc/rstudio/repos.conf && \
 	echo 'CRAN_1=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/' >> /etc/rstudio/repos.conf && \
+	echo 'r-restore-workspace=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-timeout-minutes=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-save-action-default=no' >> /etc/rstudio/rsession.conf && \
 	echo 'session-rprofile-on-resume-default=1' >> /etc/rstudio/rsession.conf && \

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -96,12 +96,12 @@ RUN \
 	echo 'server-daemonize=0' >> /etc/rstudio/rserver.conf && \
 	echo 'setHook("rstudio.sessionInit", function(newSession) {' > /usr/lib/R/etc/Rprofile.site && \
 	echo '	if (newSession) {' >> /usr/lib/R/etc/Rprofile.site && \
-  echo '		message("Welcome to RStudio [New Session]")' >> /usr/lib/R/etc/Rprofile.site && \
-  echo '		readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
-  echo '  } else {' >> /usr/lib/R/etc/Rprofile.site && \
-  echo '		message("Welcome to RStudio [Restored Session with New Credentials]")' >> /usr/lib/R/etc/Rprofile.site && \
-  echo '		readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
-  echo '	}' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '		message("Welcome to RStudio [New Session]")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '		readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '  } else {' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '		message("Welcome to RStudio [Restored Session with New Credentials]")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '		readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '	}' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '}, action = "append")' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '' >> /usr/lib/R/etc/Rprofile.site && \
 	echo 'local({' >> /usr/lib/R/etc/Rprofile.site && \

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -104,6 +104,7 @@ RUN \
 	echo 'CRAN_1=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/' >> /etc/rstudio/repos.conf && \
 	echo 'session-timeout-minutes=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-save-action-default=no' >> /etc/rstudio/rsession.conf && \
+	echo 'session-rprofile-on-resume-default=1' >> /etc/rstudio/rsession.conf && \
 	Rscript -e 'install.packages("/exploretiva", repos=NULL, type="source")' && \
 	Rscript -e 'install.packages(c("aws.s3", "aws.ec2metadata", "ggraph", "igraph", "RPostgres", "text2vec", "tidytext", "tm", "topicmodels", "widyr", "wordcloud2", "tidyverse", "devtools", "plotly", "shiny", "leaflet", "shinydashboard", "sf", "shinycssloaders"), repos=c("https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/", "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"), clean=TRUE)'
 

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -94,16 +94,16 @@ RUN \
 	echo 'www-port=8888' >> /etc/rstudio/rserver.conf && \
 	echo 'auth-none=1' >> /etc/rstudio/rserver.conf && \
 	echo 'server-daemonize=0' >> /etc/rstudio/rserver.conf && \
-	echo 'readRenviron("/usr/lib/R/etc/Renviron.site")' > /usr/lib/R/etc/Rprofile.site && \
-	echo 'local({' >> /usr/lib/R/etc/Rprofile.site && \
+	echo 'local({' > /usr/lib/R/etc/Rprofile.site && \
+	echo '	readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r = getOption("repos")' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/"' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN_1"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  options(repos = r)' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '})' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '' >> /usr/lib/R/etc/Rprofile.site && \
 	echo 'CRAN=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/' >> /etc/rstudio/repos.conf && \
 	echo 'CRAN_1=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/' >> /etc/rstudio/repos.conf && \
-	echo 'r-restore-workspace=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-timeout-minutes=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-save-action-default=no' >> /etc/rstudio/rsession.conf && \
 	echo 'session-rprofile-on-resume-default=1' >> /etc/rstudio/rsession.conf && \

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -94,8 +94,17 @@ RUN \
 	echo 'www-port=8888' >> /etc/rstudio/rserver.conf && \
 	echo 'auth-none=1' >> /etc/rstudio/rserver.conf && \
 	echo 'server-daemonize=0' >> /etc/rstudio/rserver.conf && \
-	echo 'local({' > /usr/lib/R/etc/Rprofile.site && \
-	echo '	readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo 'setHook("rstudio.sessionInit", function(newSession) {' > /usr/lib/R/etc/Rprofile.site && \
+	echo '	if (newSession) {' >> /usr/lib/R/etc/Rprofile.site && \
+  echo '		message("Welcome to RStudio [New Session]")' >> /usr/lib/R/etc/Rprofile.site && \
+  echo '		readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
+  echo '  } else {' >> /usr/lib/R/etc/Rprofile.site && \
+  echo '		message("Welcome to RStudio [Restored Session with New Credentials]")' >> /usr/lib/R/etc/Rprofile.site && \
+  echo '		readRenviron("/usr/lib/R/etc/Renviron.site")' >> /usr/lib/R/etc/Rprofile.site && \
+  echo '	}' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '}, action = "append")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '' >> /usr/lib/R/etc/Rprofile.site && \
+	echo 'local({' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r = getOption("repos")' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/"' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN_1"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /usr/lib/R/etc/Rprofile.site && \
@@ -105,7 +114,6 @@ RUN \
 	echo 'CRAN=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary-rv4/' >> /etc/rstudio/repos.conf && \
 	echo 'CRAN_1=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/' >> /etc/rstudio/repos.conf && \
 	echo 'session-rprofile-on-resume-default=1' >> /etc/rstudio/rsession.conf && \
-	echo 'session-timeout-suspend=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-timeout-minutes=0' >> /etc/rstudio/rsession.conf && \
 	echo 'session-save-action-default=no' >> /etc/rstudio/rsession.conf && \
 	Rscript -e 'install.packages("/exploretiva", repos=NULL, type="source")' && \


### PR DESCRIPTION
fix: rstudio session to load in new aws credentials when rstudio resets from an expired session