### PR TITLE
feat: add direnv to the install packages list (and tighten up base image version)

### DIFF
--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-20240812
 
 RUN \
     apt-get update && \
@@ -16,7 +16,6 @@ ENV \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    LD_LIBRARY_PATH=/lib \
     CONDA_DIR=/opt/conda
 
 ENV \
@@ -32,7 +31,8 @@ RUN \
         ssh \
         vim \
         emacs \
-        wget && \
+        wget \
+        direnv && \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye main" > /etc/apt/sources.list && \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye-updates main" >> /etc/apt/sources.list && \
     echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \

--- a/rstudio-rv4/Dockerfile
+++ b/rstudio-rv4/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-20240812
 
 RUN \
 	echo "deb [trusted=yes] https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye main" > /etc/apt/sources.list && \
@@ -72,7 +72,8 @@ RUN \
 		man-db \
 		vim \
 		emacs \
-		wget && \
+		wget \
+		direnv && \
 	wget -q https://download2.rstudio.org/server/bionic/amd64/rstudio-server-2023.03.0-386-amd64.deb && \
 	echo "8dcc6003cce4cf41fbbc0fd2c37c343311bbcbfa377d2e168245ab329df835b5  rstudio-server-2023.03.0-386-amd64.deb" | sha256sum -c && \
 	gdebi --non-interactive rstudio-server-2023.03.0-386-amd64.deb && \

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20240211
+FROM debian:bullseye-20240812
 
 RUN \
 	apt-get update && \
@@ -42,7 +42,8 @@ RUN \
 		procps \
 		sudo \
 		pkg-config \
-		libsecret-1-dev && \
+		libsecret-1-dev \
+		direnv && \
 	curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm /etc/apt/sources.list.d/nodesource.list && \


### PR DESCRIPTION
It has been requested by a user to make it easier to manage environment variables between different projects.

Also removing the specification of LD_LIBRARY_PATH from the JupyterLab Dockerfile to fix the error:

> LD_LIBRARY_PATH contains the traditional /lib directory, but not the multiarch directory /lib/x86_64-linux-gnu. It is not safe to upgrade the C library in this situation; please remove the /lib/directory from LD_LIBRARY_PATH and try again.

Also taking the opportunity to pin the base image version a bit more to avoid unexpected changes (or even just wondering if a problem is caused by the image not being pinned).