### PR TITLE
feat: speculatively increase pgAdmin connection timeout

### DIFF
--- a/pgadmin/config_local.py
+++ b/pgadmin/config_local.py
@@ -138,6 +138,7 @@ for i, (name, dsn) in enumerate(env.get("DATABASE_DSN", {}).items()):
         "SSLMode": "prefer",
         "MaintenanceDB": "postgres",
         "PassFile": passfile,
+        "Timeout": 180,
     }
 
 with open(passfile, "w") as f:


### PR DESCRIPTION
I _think_ the timeout for getting connections is by default 10 seconds, and sometimes we get up to ~60 seconds. This should increase the connection timeout to 180 seconds.

Note I'm not 100% that this is even the right setting: it's an educated guess.