### PR TITLE
refactor: remove unnecessary plugin download step in Theia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,6 @@ RUN \
     cd /root && \
     curl -o- -L https://yarnpkg.com/install.sh | bash && \
 	yarn install && \
-	yarn theia download:plugins && \
 	yarn theia build && \
 	yarn cache clean && \
 	find /root -type d -exec chmod 755 {} + && \


### PR DESCRIPTION
The other steps seem to do this, so no need to do it twice