### PR TITLE
refactor: remove unnecessary step from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,6 @@ RUN \
     cd /root && \
     curl -o- -L https://yarnpkg.com/install.sh | bash && \
 	yarn install && \
-	yarn theia build && \
 	yarn cache clean && \
 	find /root -type d -exec chmod 755 {} + && \
 	chmod -R +r /root && \

--- a/python-theia/package.json
+++ b/python-theia/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "prepare": "yarn run clean && yarn build && yarn run download:plugins",
     "clean": "theia clean",
-    "build": "theia build --mode development",
+    "build": "theia build",
     "start": "theia start --plugins=local-dir:plugins",
     "download:plugins": "theia download:plugins"
   },


### PR DESCRIPTION
Removing unnecessary step from Dockerfile - it's done via "prepare" which is run automatically by yarn install