### PR TITLE
refactor: use default plugins dir

### DIFF
--- a/python-theia/package.json
+++ b/python-theia/package.json
@@ -40,7 +40,6 @@
     "**/nano": "^10.1.2",
     "**/msgpackr": "^1.10.1"
   },
-  "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-extensions-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.1/file/eclipse-theia.builtin-extension-pack-1.50.1.vsix",
     "vscode-python": "https://github.com/microsoft/vscode-python/releases/download/2020.8.109390/ms-python-release.vsix",

--- a/python-theia/start.sh
+++ b/python-theia/start.sh
@@ -10,7 +10,6 @@ echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
 
 cd /root
 exec sudo -E -H -u dw-user yarn theia start /home/dw-user \
-	--plugins=local-dir:/root/plugins \
 	--hostname=0.0.0.0 \
 	--port=8888 \
 	--cache-folder=/tmp/.yarn-cache


### PR DESCRIPTION
Now we download plugins (including our own) we shouldn't need config