### PR TITLE
feat: add new private package index to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,6 +155,7 @@ RUN \
     \
     echo '[global]' > /etc/pip.conf && \
     echo 'index-url = https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/pypi/' >> /etc/pip.conf && \
+    echo 'extra-index-url = https://s3-eu-west-2.amazonaws.com/jupyter.notebook.uktrade.io/shared/ddat_packages/pypi/' >> /etc/pip.conf && \
     echo 'no-cache-dir = false' >> /etc/pip.conf
 
 COPY \


### PR DESCRIPTION
We have a new bucket area for DDaT data science packages to be added from Gitlab. This change should make pip install look in this bucket area for packages as well as the mirror bucket