### PR TITLE
feat: add basic dw-rstudio-in-rstudio script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -367,6 +367,7 @@ RUN \
     echo '' >> /usr/lib/R/etc/Rprofile.site
 
 COPY rv4-rstudio/rstudio-start.sh /
+COPY rv4-rstudio/dw-rstudio-in-rstudio /usr/bin/dw-rstudio-in-rstudio
 
 CMD ["/rstudio-start.sh"]
 

--- a/rv4-rstudio/dw-rstudio-in-rstudio
+++ b/rv4-rstudio/dw-rstudio-in-rstudio
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+/usr/lib/rstudio-server/bin/rserver --server-daemonize=0 --server-user=dw-user --www-port 9000  --server-data-dir=/tmp/rstudio-server-9000


### PR DESCRIPTION
There are a few use cases where it's helpful to have multiple RStudios, e.g. to have multiple interactive consoles at once. While maybe a bit odd, we can leverage Data Workspace's "--9000" system for developing visualisations for running an RStudio from inside RStudio.