### PR TITLE
fix: use existing "vscode" ECR repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
             value: '' +
                 'python-jupyterlab|jupyterlab-python|master,' +
                 'python-theia|theia|master,' +
-                'python-vscode|vs-code|master,' +
+                'python-vscode|vscode|master,' +
                 'python-visualisation|visualisation-base|python,' +
                 'rv4-cran-binary-mirror|mirrors-sync-cran-binary-rv4|master,' +
                 'rv4-rstudio|rstudio-rv4|master,' +


### PR DESCRIPTION
There is an existing "vscode" repo in ECR, and not "vs-code" and we can/should use the existing one without a dash (it was setup for experimentation, which is fine for us to now use proper).