### PR TITLE
feat: conda and Python notebooks working in VS Code

### DIFF
--- a/python-vscode/settings.json
+++ b/python-vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "terminal.integrated.profiles.linux": {
+    "bash": {
+      "path": "/bin/bash",
+      "icon": "terminal-bash",
+      "args": [
+        "-l"
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "python.defaultInterpreterPath": "/opt/conda/bin/python3"
+}

--- a/python-vscode/start.sh
+++ b/python-vscode/start.sh
@@ -8,5 +8,6 @@ set -e
 # Java programs can error if $HOSTNAME is not resolvable
 echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
 
-cd /root
-exec sudo -E -H -u dw-user code-server --auth none --bind-addr 0.0.0.0:8888
+chown -R dw-user:dw-user /etc/code-server
+cd /home/dw-user
+exec sudo -E -H -u dw-user code-server --user-data-dir /etc/code-server --auth none --bind-addr 0.0.0.0:8888


### PR DESCRIPTION
Similar to other python-theia, we activate conda when launching a bash login shell (which needs VS Code specific configuration to start).

Python notebooks are enabled by installing the relevant extensions

Getting Python notebooks working requires a modification to the VS Code / code-server codebase, to rewrite domains that request resources under subdomains of vscode-cdn.net to an invalid domain. This rewrite allows us to open up the CSP on data workspace to this invalid domain, without actually increasing the risk of data leakage. The reason why this actually helps is because VS Code has service workers that intercept such requests and responds with the correct content served internally, without communicating with the internet.