### PR TITLE
feat: consistently activate conda in all Python tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,11 @@ RUN \
     echo 'extra-index-url = https://s3-eu-west-2.amazonaws.com/jupyter.notebook.uktrade.io/shared/ddat_packages/pypi/' >> /etc/pip.conf && \
     echo 'no-cache-dir = false' >> /etc/pip.conf
 
+# Activate conda when launching a bash login shell
+RUN \
+    echo "conda activate base" >> /etc/profile && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
 COPY \
     python/requirements.txt /root/
 
@@ -214,9 +219,7 @@ RUN \
 	mkdir /tmp/.yarn-cache && \
 	chown dw-user:dw-user /tmp/.yarn-cache && \
 	touch /root/yarn-error.log && \
-	chown dw-user:dw-user /root/yarn-error.log && \
-	echo "conda activate base" >> /etc/profile && \
-	ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+	chown dw-user:dw-user /root/yarn-error.log
 
 COPY python-theia/start.sh /start.sh
 
@@ -227,11 +230,6 @@ CMD ["/start.sh"]
 # VS Code
 
 FROM python AS python-vscode
-
-# Activate conda when launching a bash login shell
-RUN \
-    echo "conda activate base" >> /etc/profile && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
 
 # Install VS Code (via code-server) and extensions
 RUN \

--- a/python-jupyterlab/jupyter_notebook_config.py
+++ b/python-jupyterlab/jupyter_notebook_config.py
@@ -32,4 +32,4 @@ c = get_config()  # pylint: disable=undefined-variable # noqa
 
 c.NotebookApp.ip = "0.0.0.0"
 c.NotebookApp.log_level = "DEBUG"
-c.NotebookApp.terminado_settings = {"shell_command": ["bash"]}
+c.NotebookApp.terminado_settings = {"shell_command": ["bash", "-l"]}


### PR DESCRIPTION
This is done for 2 reasons

- Purely user-facing to have a more consistent experience
- For the upcoming move to bookworm - it more strongly forbids install of Python packages in the root environment except those that can be installed through apt install. So suspect that all packages will have to managed by conda in all tools.