### PR TITLE
feat: install Python packages with conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,8 +172,12 @@ COPY \
 COPY \
     private_package_index/create_index_html.py /
 
-
+# Install Python packages via conda which makes them available to users, and avoids conflicts/
+# errors/warnings with Debian Python packages
 RUN \
+    conda init && \
+    . ~/.bashrc && \
+    conda activate base && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     python3 -m pip install -r /root/requirements.txt && \
     chown -R dw-user:dw-user /usr/local && \


### PR DESCRIPTION
This activates conda inside the Dockerfile, so Python packages are installed into a conda environment/virtual environment.

This is to ease our move to bookworm, where it strictly forbids pip install of packages.