### PR TITLE
refactor: really install s3sync in venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -533,12 +533,12 @@ RUN \
     apt update && \
     apt install -y sudo python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/* && \
-    python3 -m venv /venv && \
-    . /venv/bin/activate
+    python3 -m venv /venv
 
 COPY s3sync/requirements.txt /app/
 
 RUN \
+    . /venv/bin/activate && \
     pip3 install \
         -r /app/requirements.txt
 


### PR DESCRIPTION
In order to move to Debian bookworm, which is stricter in terms of not installing Python packages in the root env that are not Debian-y, we need to install package always via a virtual environment.

In a previous change I thought we did this for s3sync, but I placed the "activate" in the wrong RUN part of the Dockerfile.