### PR TITLE
feat: add vscode-postgres to VSCode

### DIFF
--- a/python-vscode/settings.json
+++ b/python-vscode/settings.json
@@ -9,5 +9,8 @@
     }
   },
   "terminal.integrated.defaultProfile.linux": "bash",
-  "python.defaultInterpreterPath": "/opt/conda/bin/python3"
+  "python.defaultInterpreterPath": "/opt/conda/bin/python3",
+  "vscode-postgres.defaultConnection": "datasets",
+  "vscode-postgres.defaultDatabase": "public_datasets_1",
+  "vscode-postgres.virtualFolders": []
 }


### PR DESCRIPTION
We use theia-postgres in Theia, so this is a step towards feature parity between the two, in order to eventually remove Theia.

As described in the comment in the Dockerfile, vscode-postgres doesn't have an out-of-the-box way of automatically configuring the connection, so we monkey-patch it do so