### PR TITLE
build: upgraded hypercorn

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -88,7 +88,9 @@ distlib==0.3.9
 exceptiongroup==1.2.2
     # via
     #   anyio
+    #   hypercorn
     #   ipython
+    #   taskgroup
 executing==1.2.0
     # via stack-data
 fastjsonschema==2.18.0
@@ -118,7 +120,7 @@ httpx==0.25.1
     # via
     #   git-lfs-http-mirror
     #   jupyterlab
-hypercorn==0.14.4
+hypercorn==0.17.3
     # via
     #   git-lfs-http-mirror
     #   quart
@@ -428,6 +430,8 @@ sqlparse==0.5.0
     # via ipython-sql
 stack-data==0.6.2
     # via ipython
+taskgroup==0.2.2
+    # via hypercorn
 terminado==0.17.1
     # via
     #   jupyter-server
@@ -464,12 +468,14 @@ traitlets==5.9.0
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
     #   async-lru
+    #   hypercorn
     #   ipython
     #   quart
     #   sqlalchemy
+    #   taskgroup
 tzdata==2023.3
     # via pandas
 uri-template==1.3.0


### PR DESCRIPTION
This upgrades the version of 'hypercorn' from 0.14.4 to 0.17.3 to avoid CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-44487.