### PR TITLE
Update Jenkinsfile to use new Kubernetes secret

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,8 +92,8 @@ pipeline {
                           mountPath: /kaniko/.docker
                       volumes:
                       - name: jenkins-docker-cfg
-                        configMap:
-                          name: docker-config
+                        secret:
+                          secretName: jenkins-data-workspace
                           items:
                           - key: config.json
                             path: config.json


### PR DESCRIPTION
Configmap was changed to secret when EKS cluster was rebuilt as it contained credentials.