### PR TITLE
feat: install git filter repo on python base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,7 +165,9 @@ RUN \
     echo "conda activate base" >> /etc/profile && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     # Install conda's default solver (which strangely doesn't seem to get installed by default)
-    conda install conda-libmamba-solver --name base
+    conda install conda-libmamba-solver --name base && \
+    # Install git filter repo so removal of data is a little easier
+    conda install git-filter-repo --name base
 
 # Activate conda for the CMD of any Docker stage that derives from this one
 ENTRYPOINT ["/opt/conda/bin/conda", "run", "--no-capture-output", "--name", "base"]


### PR DESCRIPTION
After some issues with data being stored where it shouldn't be, we have some documentation for deleting data and rewriting history. This always involves installing git-filter-repo, so installing it on the Python base image means we can skip a step in these docs