### PR TITLE
feat: ability for VS Code settings to persist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,9 +245,10 @@ FROM python AS python-vscode
 # Install VS Code (via code-server) and extensions
 RUN \
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.96.2 && \
-    code-server --user-data-dir /etc/code-server --install-extension ms-python.python@2024.22.1 && \
-    code-server --user-data-dir /etc/code-server --install-extension ms-toolsai.jupyter@2024.11.0 && \
-    code-server --user-data-dir /etc/code-server --install-extension ckolkman.vscode-postgres@1.4.3
+    code-server --extensions-dir /etc/code-server-extensions --user-data-dir /home/dw-user/.vscode --install-extension ms-python.python@2024.22.1 && \
+    code-server --extensions-dir /etc/code-server-extensions --user-data-dir /home/dw-user/.vscode --install-extension ms-toolsai.jupyter@2024.11.0 && \
+    code-server --extensions-dir /etc/code-server-extensions --user-data-dir /home/dw-user/.vscode --install-extension ckolkman.vscode-postgres@1.4.3 && \
+    rm -r -f /home/dw-user/.vscode
 
 # VS Code in the browser make requests subdomains of vscode-cdn.net... but these are rewritten
 # by service workers and handled internally. So to allow us to still have quite a locked down CSP,
@@ -262,9 +263,10 @@ RUN \
 # one, and since it seems to use libpq under the hood, it will automatically take credentials
 # from environment variables
 RUN \
-    echo -e "\nexports.activate = (context) => {context.globalState.update('postgresql.connections',{'00000000-0000-4000-8000-000000000000':{label:'datasets',hasPassword:false,ssl:true,certPath:'/certs/rds-global-bundle.pem',database:'public_datasets_1',host:'',user:'',port:''}});activate(context);};" >> /etc/code-server/extensions/ckolkman.vscode-postgres-1.4.3-universal/out/extension.js
+    echo -e "\nexports.activate = (context) => {context.globalState.update('postgresql.connections',{'00000000-0000-4000-8000-000000000000':{label:'datasets',hasPassword:false,ssl:true,certPath:'/certs/rds-global-bundle.pem',database:'public_datasets_1',host:'',user:'',port:''}});activate(context);};" >> /etc/code-server-extensions/ckolkman.vscode-postgres-1.4.3-universal/out/extension.js
 
-COPY python-vscode/settings.json /etc/code-server/User/settings.json
+COPY python-vscode/merge-settings.py /merge-settings.py
+COPY python-vscode/settings.json /etc/code-server-defaults/settings.json
 COPY python-vscode/start.sh /start.sh
 
 CMD ["/start.sh"]

--- a/python-vscode/merge-settings.py
+++ b/python-vscode/merge-settings.py
@@ -1,0 +1,53 @@
+"""Merges user-settings (saved from previous launches of VS Code) with default settings.
+
+VS Code / code-server doesn't seem to provide a way of having a hierachy of settings, where some
+settings are set system-wide by admins. So this file does that - merges user settings with default
+settings.
+
+Because of race conditions with s3sync/mobius3, it manually takes the previous settings file from
+the user's folder in the bucket, merges it with the default, and re-uploads the merged version to
+the bucket.
+"""
+
+import os
+import json
+import sys
+
+import boto3
+
+
+s3 = boto3.client('s3')
+
+try:
+    user_settings = json.loads(s3.get_object(
+        Bucket=os.environ["S3_BUCKET"],
+        Key=os.environ["S3_PREFIX"] + '.vscode/User/settings.json',
+    )['Body'].read())
+except KeyError:
+    print("Missing S3_BUCKET or S3_PREFIX environment variable. Skipping fetching user settings since probably running locally.")
+    user_settings = {}
+except json.JSONDecodeError:
+    user_settings = {}
+except s3.exceptions.NoSuchKey:
+    user_settings = {}
+
+with open('/etc/code-server-defaults/settings.json', 'rb') as f:
+    default_settings = json.loads(f.read())
+
+merged_settings = json.dumps({
+    **user_settings,
+    **default_settings,
+}).encode('utf-8')
+
+os.makedirs('/home/dw-user/.vscode/User')
+with open('/home/dw-user/.vscode/User/settings.json', 'wb') as f:
+    f.write(merged_settings)
+
+try:
+    s3.put_object(
+        Body=merged_settings,
+        Bucket=os.environ["S3_BUCKET"],
+        Key=os.environ["S3_PREFIX"] + '.vscode/User/settings.json',
+    )
+except KeyError:
+    print("Missing S3_BUCKET or S3_PREFIX environment variable. Skipping putting user settings since probably running locally.")

--- a/python-vscode/start.sh
+++ b/python-vscode/start.sh
@@ -8,6 +8,10 @@ set -e
 # Java programs can error if $HOSTNAME is not resolvable
 echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
 
-chown -R dw-user:dw-user /etc/code-server
+python /merge-settings.py
+
+chown -R dw-user:dw-user /home/dw-user/.vscode
+chown -R dw-user:dw-user /etc/code-server-extensions
+
 cd /home/dw-user
-exec sudo -E -H -u dw-user code-server --user-data-dir /etc/code-server --auth none --bind-addr 0.0.0.0:8888
+exec sudo -E -H -u dw-user code-server --extensions-dir /etc/code-server-extensions --user-data-dir /home/dw-user/.vscode --auth none --bind-addr 0.0.0.0:8888


### PR DESCRIPTION
This moves the user-data-dir for VS Code (via code-server) into the home directory, which contains VS Code gets persisted to S3 and so preserves settings between launches.

There are 2 complications to this however:

- We do need to enforce a few initial/default settings. There doesn't seem to be a built-in way of doing this, so a custom Python script is included that merges the default settings with the user's. We always override the users with the initial/default. Maybe down the line this would need to be more intelligent to allow users to change some of the initial settings.

- The extensions directory is by default part of user-data-dir, but we also need to include a list of initial/default extensions that users should not be able to remove. So for now it is configured outside of the home directory, populated with the same extensions as before, and so not persisted. In a future change we can try to figure out how to do something similar as to settings: include some non-changeable extensions, but also allow users to add some.