### PR TITLE
fix: race condition when merging VS Code settings

### DIFF
--- a/python-vscode/merge-settings.py
+++ b/python-vscode/merge-settings.py
@@ -39,7 +39,7 @@ merged_settings = json.dumps({
     **default_settings,
 }).encode('utf-8')
 
-os.makedirs('/home/dw-user/.vscode/User')
+os.makedirs('/home/dw-user/.vscode/User', exist_ok=True)
 with open('/home/dw-user/.vscode/User/settings.json', 'wb') as f:
     f.write(merged_settings)
 


### PR DESCRIPTION
The passes exist_ok=True to os.makedirs when creating the folder for VS Code settings, avoiding an error if the folder already exists.

This is to address a race condition when loading VS Code - if the S3 sync process has already created the User directory, then creating it again causes a FileExistsError, and VS Code fails to launch. This appears to be a bit more common when we have an EFS volume which so far we only have in staging - presumably it slows down the launch a bit of the main container so the sync process has had more time to create the directory.