### PR TITLE
feat: install cmake in R images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -354,6 +354,7 @@ RUN \
     rm -rf /var/lib/apt/lists/* && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
+		cmake \
 		emacs \
 		gdebi-core \
 		gfortran \


### PR DESCRIPTION
There is at least one package being used within Rstudio that needs CMake and user would rather not have to install this on every boot of the tool. Installing in the image instead to make this process nicer and maybe support other packages that use Cmake in future