### PR TITLE
revert: remove cmake from r images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -354,7 +354,6 @@ RUN \
     rm -rf /var/lib/apt/lists/* && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		cmake \
 		emacs \
 		gdebi-core \
 		gfortran \


### PR DESCRIPTION
not sure what the issue is yet, but since this Rstudio instances aren't starting, removing to test on staging before trying again