### PR TITLE
feat: update RStudio server version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -452,10 +452,10 @@ FROM rv4-common-packages AS rv4-rstudio
 RUN \
     # Install RStudio
     apt-get update && \
-    wget -q https://download2.rstudio.org/server/bionic/amd64/rstudio-server-2023.03.0-386-amd64.deb && \
-    echo "8dcc6003cce4cf41fbbc0fd2c37c343311bbcbfa377d2e168245ab329df835b5  rstudio-server-2023.03.0-386-amd64.deb" | sha256sum -c && \
-    gdebi --non-interactive rstudio-server-2023.03.0-386-amd64.deb && \
-    rm rstudio-server-2023.03.0-386-amd64.deb && \
+    wget -q https://download2.rstudio.org/server/focal/amd64/rstudio-server-2025.05.0-496-amd64.deb && \
+    echo "b8fb933f5466f980b36d2eba001ef90be57d5689789c30d012852564d0c77218 rstudio-server-2025.05.0-496-amd64.deb" | sha256sum -c && \
+    gdebi --non-interactive rstudio-server-2025.05.0-496-amd64.deb && \
+    rm rstudio-server-2025.05.0-496-amd64.deb && \
     rm -rf /var/lib/apt/lists/* && \
     \
     # Configure RStudio


### PR DESCRIPTION
This updates version from 2023 to 2025.

Rstudio 4.5 has incompatibility with the server version 2023 and gives an error `symbol lookup error: /usr/lib/rstudio-server/bin/rsession: undefined symbol: Rf_countContexts`.